### PR TITLE
以内容同步方式合入 Qwen3.5 GGUF gfx906 优化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ endif()
 
 set(VLLM_EXT_SRC
   "csrc/mamba/mamba_ssm/selective_scan_fwd.cu"
+  "csrc/mamba/gfx906_decode_kernels.cu"
   "csrc/cache_kernels.cu"
   "csrc/attention/paged_attention_v1.cu"
   "csrc/attention/paged_attention_v2.cu"

--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -179,6 +179,122 @@ fused_add_rms_norm_kernel(
   }
 }
 
+template <typename scalar_t>
+__global__ void rms_norm_gated_gfx906_kernel(
+    scalar_t* __restrict__ out, const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ weight, const scalar_t* __restrict__ gate,
+    const float epsilon, const int hidden_size, const int64_t input_stride,
+    const int64_t gate_stride, const bool norm_before_gate) {
+  __shared__ float s_variance;
+  float variance = 0.0f;
+
+  const int64_t row = blockIdx.x;
+  const scalar_t* input_row = input + row * input_stride;
+  const scalar_t* gate_row = gate + row * gate_stride;
+
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    float x = static_cast<float>(input_row[idx]);
+    if (!norm_before_gate) {
+      float z = static_cast<float>(gate_row[idx]);
+      x *= z / (1.0f + expf(-z));
+    }
+    variance += x * x;
+  }
+
+  using BlockReduce = cub::BlockReduce<float, 1024>;
+  __shared__ typename BlockReduce::TempStorage reduceStore;
+  variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
+
+  if (threadIdx.x == 0) {
+    s_variance = rsqrtf(variance / hidden_size + epsilon);
+  }
+  __syncthreads();
+
+  scalar_t* out_row = out + row * hidden_size;
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    float x = static_cast<float>(input_row[idx]);
+    float z = static_cast<float>(gate_row[idx]);
+    const float gate_val = z / (1.0f + expf(-z));
+    float val = norm_before_gate ? x * s_variance * gate_val
+                                 : x * gate_val * s_variance;
+    val *= static_cast<float>(weight[idx]);
+    out_row[idx] = static_cast<scalar_t>(val);
+  }
+}
+
+template <typename scalar_t>
+__global__ void gemma_rms_norm_gfx906_kernel(
+    scalar_t* __restrict__ out, const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ weight, const float epsilon,
+    const int hidden_size, const int64_t input_stride) {
+  __shared__ float s_variance;
+  float variance = 0.0f;
+
+  const int64_t row = blockIdx.x;
+  const scalar_t* input_row = input + row * input_stride;
+
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    float x = static_cast<float>(input_row[idx]);
+    variance += x * x;
+  }
+
+  using BlockReduce = cub::BlockReduce<float, 1024>;
+  __shared__ typename BlockReduce::TempStorage reduceStore;
+  variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
+
+  if (threadIdx.x == 0) {
+    s_variance = rsqrtf(variance / hidden_size + epsilon);
+  }
+  __syncthreads();
+
+  scalar_t* out_row = out + row * hidden_size;
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    const float x = static_cast<float>(input_row[idx]);
+    const float w = 1.0f + static_cast<float>(weight[idx]);
+    out_row[idx] = static_cast<scalar_t>(x * s_variance * w);
+  }
+}
+
+template <typename scalar_t, typename residual_t>
+__global__ void gemma_fused_add_rms_norm_gfx906_kernel(
+    scalar_t* __restrict__ out, float* __restrict__ residual_out,
+    const scalar_t* __restrict__ input,
+    const residual_t* __restrict__ residual,
+    const scalar_t* __restrict__ weight, const float epsilon,
+    const int hidden_size, const int64_t input_stride,
+    const int64_t residual_stride) {
+  __shared__ float s_variance;
+  float variance = 0.0f;
+
+  const int64_t row = blockIdx.x;
+  const scalar_t* input_row = input + row * input_stride;
+  const residual_t* residual_row = residual + row * residual_stride;
+  float* residual_out_row = residual_out + row * hidden_size;
+
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    const float x = static_cast<float>(input_row[idx]) +
+                    static_cast<float>(residual_row[idx]);
+    variance += x * x;
+    residual_out_row[idx] = x;
+  }
+
+  using BlockReduce = cub::BlockReduce<float, 1024>;
+  __shared__ typename BlockReduce::TempStorage reduceStore;
+  variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
+
+  if (threadIdx.x == 0) {
+    s_variance = rsqrtf(variance / hidden_size + epsilon);
+  }
+  __syncthreads();
+
+  scalar_t* out_row = out + row * hidden_size;
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    const float x = residual_out_row[idx];
+    const float w = 1.0f + static_cast<float>(weight[idx]);
+    out_row[idx] = static_cast<scalar_t>(x * s_variance * w);
+  }
+}
+
 }  // namespace vllm
 
 void rms_norm(torch::Tensor& out,     // [..., hidden_size]
@@ -283,4 +399,152 @@ void fused_add_rms_norm(torch::Tensor& input,     // [..., hidden_size]
   } else {
     LAUNCH_FUSED_ADD_RMS_NORM(0);
   }
+}
+
+torch::Tensor rms_norm_gated_gfx906(torch::Tensor input,    // [..., hidden_size]
+                                    torch::Tensor weight,   // [hidden_size]
+                                    torch::Tensor gate,     // [..., hidden_size]
+                                    double epsilon,
+                                    bool norm_before_gate) {
+  TORCH_CHECK(input.is_cuda(), "input must be a CUDA tensor");
+  TORCH_CHECK(gate.is_cuda(), "gate must be a CUDA tensor");
+  TORCH_CHECK(weight.is_cuda(), "weight must be a CUDA tensor");
+  TORCH_CHECK(input.scalar_type() == gate.scalar_type(),
+              "input and gate must have the same dtype");
+  TORCH_CHECK(input.scalar_type() == weight.scalar_type(),
+              "input and weight must have the same dtype");
+  TORCH_CHECK(input.sizes() == gate.sizes(),
+              "input and gate must have the same shape");
+  TORCH_CHECK(input.dim() == 2, "input must have shape [tokens, hidden_size]");
+  TORCH_CHECK(input.stride(-1) == 1, "input last dimension must be contiguous");
+  TORCH_CHECK(gate.stride(-1) == 1, "gate last dimension must be contiguous");
+  TORCH_CHECK(weight.is_contiguous(), "weight must be contiguous");
+
+  const int hidden_size = input.size(-1);
+  TORCH_CHECK(weight.numel() == hidden_size,
+              "weight size must match input hidden size");
+  const int num_tokens = input.numel() / hidden_size;
+  const int64_t input_stride = input.stride(-2);
+  const int64_t gate_stride = gate.stride(-2);
+  auto out = torch::empty_like(input, input.options().memory_format(
+                                          c10::MemoryFormat::Contiguous));
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(hidden_size, 1024));
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(),
+                               "rms_norm_gated_gfx906_kernel", [&] {
+                                 vllm::rms_norm_gated_gfx906_kernel<scalar_t>
+                                     <<<grid, block, 0, stream>>>(
+                                         out.data_ptr<scalar_t>(),
+                                         input.data_ptr<scalar_t>(),
+                                         weight.data_ptr<scalar_t>(),
+                                         gate.data_ptr<scalar_t>(), epsilon,
+                                         hidden_size, input_stride, gate_stride,
+                                         norm_before_gate);
+                               });
+  return out;
+}
+
+torch::Tensor gemma_rms_norm_gfx906(torch::Tensor input,
+                                    torch::Tensor weight,
+                                    double epsilon) {
+  TORCH_CHECK(input.is_cuda(), "input must be a CUDA tensor");
+  TORCH_CHECK(weight.is_cuda(), "weight must be a CUDA tensor");
+  TORCH_CHECK(input.scalar_type() == weight.scalar_type(),
+              "input and weight must have the same dtype");
+  TORCH_CHECK(input.dim() >= 2, "input must have at least 2 dimensions");
+  if (input.stride(-1) != 1 || !input.is_contiguous()) {
+    input = input.contiguous();
+  }
+  TORCH_CHECK(weight.is_contiguous(), "weight must be contiguous");
+
+  const int hidden_size = input.size(-1);
+  TORCH_CHECK(weight.numel() == hidden_size,
+              "weight size must match input hidden size");
+  const int num_tokens = input.numel() / hidden_size;
+  const int64_t input_stride = input.stride(-2);
+  auto out = torch::empty_like(input, input.options().memory_format(
+                                          c10::MemoryFormat::Contiguous));
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(hidden_size, 1024));
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(),
+                               "gemma_rms_norm_gfx906_kernel", [&] {
+                                 vllm::gemma_rms_norm_gfx906_kernel<scalar_t>
+                                     <<<grid, block, 0, stream>>>(
+                                         out.data_ptr<scalar_t>(),
+                                         input.data_ptr<scalar_t>(),
+                                         weight.data_ptr<scalar_t>(), epsilon,
+                                         hidden_size, input_stride);
+                               });
+  return out;
+}
+
+std::vector<torch::Tensor> gemma_fused_add_rms_norm_gfx906(
+    torch::Tensor input, torch::Tensor residual, torch::Tensor weight,
+    double epsilon) {
+  TORCH_CHECK(input.is_cuda(), "input must be a CUDA tensor");
+  TORCH_CHECK(residual.is_cuda(), "residual must be a CUDA tensor");
+  TORCH_CHECK(weight.is_cuda(), "weight must be a CUDA tensor");
+  TORCH_CHECK(input.scalar_type() == weight.scalar_type(),
+              "input and weight must have the same dtype");
+  TORCH_CHECK(residual.scalar_type() == input.scalar_type() ||
+                  residual.scalar_type() == at::ScalarType::Float,
+              "residual must be float32 or have the same dtype as input");
+  TORCH_CHECK(input.dim() >= 2, "input must have at least 2 dimensions");
+  TORCH_CHECK(residual.sizes() == input.sizes(),
+              "residual shape must match input shape");
+  if (input.stride(-1) != 1 || !input.is_contiguous()) {
+    input = input.contiguous();
+  }
+  if (residual.stride(-1) != 1 || !residual.is_contiguous()) {
+    residual = residual.contiguous();
+  }
+  TORCH_CHECK(weight.is_contiguous(), "weight must be contiguous");
+
+  const int hidden_size = input.size(-1);
+  TORCH_CHECK(weight.numel() == hidden_size,
+              "weight size must match input hidden size");
+  const int num_tokens = input.numel() / hidden_size;
+  const int64_t input_stride = input.stride(-2);
+  const int64_t residual_stride = residual.stride(-2);
+  auto out = torch::empty_like(input, input.options().memory_format(
+                                          c10::MemoryFormat::Contiguous));
+  auto residual_out =
+      torch::empty(input.sizes(),
+                   torch::TensorOptions().dtype(torch::kFloat32).device(
+                       input.device()));
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(hidden_size, 1024));
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  if (residual.scalar_type() == at::ScalarType::Float) {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        input.scalar_type(), "gemma_fused_add_rms_norm_gfx906_kernel", [&] {
+          vllm::gemma_fused_add_rms_norm_gfx906_kernel<scalar_t, float>
+              <<<grid, block, 0, stream>>>(
+                  out.data_ptr<scalar_t>(), residual_out.data_ptr<float>(),
+                  input.data_ptr<scalar_t>(), residual.data_ptr<float>(),
+                  weight.data_ptr<scalar_t>(), epsilon, hidden_size,
+                  input_stride, residual_stride);
+        });
+  } else {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        input.scalar_type(), "gemma_fused_add_rms_norm_gfx906_kernel", [&] {
+          vllm::gemma_fused_add_rms_norm_gfx906_kernel<scalar_t, scalar_t>
+              <<<grid, block, 0, stream>>>(
+                  out.data_ptr<scalar_t>(), residual_out.data_ptr<float>(),
+                  input.data_ptr<scalar_t>(), residual.data_ptr<scalar_t>(),
+                  weight.data_ptr<scalar_t>(), epsilon, hidden_size,
+                  input_stride, residual_stride);
+        });
+  }
+
+  return {out, residual_out};
 }

--- a/csrc/mamba/gfx906_decode_kernels.cu
+++ b/csrc/mamba/gfx906_decode_kernels.cu
@@ -1,0 +1,1042 @@
+#include <cuda_runtime.h>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/all.h>
+
+#include "../dispatch_utils.h"
+
+namespace {
+
+template <typename scalar_t, typename state_t>
+__global__ void causal_conv1d_gfx906_decode_update_kernel(
+    const scalar_t* __restrict__ x, state_t* __restrict__ conv_state,
+    const scalar_t* __restrict__ weight, const scalar_t* __restrict__ bias,
+    const int32_t* __restrict__ conv_state_indices, scalar_t* __restrict__ out,
+    int64_t batch, int64_t dim, int64_t width, int64_t state_len,
+    int64_t x_stride_b, int64_t x_stride_d, int64_t state_stride_b,
+    int64_t state_stride_d, int64_t state_stride_s, int64_t weight_stride_d,
+    int64_t weight_stride_w, int64_t out_stride_b, int64_t out_stride_d,
+    int64_t pad_slot_id, bool has_bias, bool silu_activation) {
+  const int64_t linear_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t total = batch * dim;
+  if (linear_idx >= total) {
+    return;
+  }
+
+  const int64_t batch_idx = linear_idx / dim;
+  const int64_t dim_idx = linear_idx - batch_idx * dim;
+  const int64_t raw_state_idx =
+      conv_state_indices == nullptr ? batch_idx : conv_state_indices[batch_idx];
+  if (raw_state_idx == pad_slot_id) {
+    out[batch_idx * out_stride_b + dim_idx * out_stride_d] =
+        static_cast<scalar_t>(0.0f);
+    return;
+  }
+  const int64_t state_idx = raw_state_idx;
+
+  float acc = has_bias ? static_cast<float>(bias[dim_idx]) : 0.0f;
+  const float x_val =
+      static_cast<float>(x[batch_idx * x_stride_b + dim_idx * x_stride_d]);
+  for (int64_t w_idx = 0; w_idx < width; ++w_idx) {
+    const int64_t source_idx = state_len - (width - 1) + w_idx;
+    const float source =
+        (w_idx == width - 1)
+            ? x_val
+            : static_cast<float>(
+                  conv_state[state_idx * state_stride_b +
+                             dim_idx * state_stride_d +
+                             source_idx * state_stride_s]);
+    acc += source *
+           static_cast<float>(
+               weight[dim_idx * weight_stride_d + w_idx * weight_stride_w]);
+  }
+  if (silu_activation) {
+    acc = acc / (1.0f + expf(-acc));
+  }
+  out[batch_idx * out_stride_b + dim_idx * out_stride_d] =
+      static_cast<scalar_t>(acc);
+
+  if (state_len <= 0) {
+    return;
+  }
+  const int64_t keep_old = min(width - 1, state_len - 1);
+  const int64_t target_start = state_len - 1 - keep_old;
+  for (int64_t s_idx = 0; s_idx < target_start; ++s_idx) {
+    conv_state[state_idx * state_stride_b + dim_idx * state_stride_d +
+               s_idx * state_stride_s] = static_cast<state_t>(0.0f);
+  }
+  for (int64_t s_idx = 0; s_idx < keep_old; ++s_idx) {
+    const int64_t source_idx = state_len - keep_old + s_idx;
+    const int64_t target_idx = target_start + s_idx;
+    conv_state[state_idx * state_stride_b + dim_idx * state_stride_d +
+               target_idx * state_stride_s] =
+        conv_state[state_idx * state_stride_b + dim_idx * state_stride_d +
+                   source_idx * state_stride_s];
+  }
+  conv_state[state_idx * state_stride_b + dim_idx * state_stride_d +
+             (state_len - 1) * state_stride_s] = static_cast<state_t>(x_val);
+}
+
+template <typename scalar_t, typename state_t>
+__global__ void fused_sigmoid_gating_delta_rule_gfx906_decode_kernel(
+    const scalar_t* __restrict__ A_log, const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b, const scalar_t* __restrict__ dt_bias,
+    const scalar_t* __restrict__ q, const scalar_t* __restrict__ k,
+    const scalar_t* __restrict__ v, state_t* __restrict__ state,
+    scalar_t* __restrict__ out, int64_t tokens, int64_t heads, int64_t kv_heads,
+    int64_t key_dim, int64_t value_dim, int64_t q_stride_t,
+    int64_t q_stride_h, int64_t q_stride_k, int64_t k_stride_t,
+    int64_t k_stride_h, int64_t k_stride_k, int64_t v_stride_t,
+    int64_t v_stride_h, int64_t v_stride_v, int64_t a_stride_t,
+    int64_t a_stride_h, int64_t b_stride_t, int64_t b_stride_h,
+    int64_t state_stride_t, int64_t state_stride_h, int64_t state_stride_v,
+    int64_t state_stride_k, int64_t out_stride_t, int64_t out_stride_h,
+    int64_t out_stride_v, double beta, double threshold, double scale,
+    bool use_qk_l2norm_in_kernel) {
+  const int64_t linear_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t total = tokens * kv_heads * value_dim;
+  if (linear_idx >= total) {
+    return;
+  }
+
+  const int64_t value_idx = linear_idx % value_dim;
+  const int64_t hv_idx = (linear_idx / value_dim) % kv_heads;
+  const int64_t token_idx = linear_idx / (value_dim * kv_heads);
+  const int64_t head_ratio = kv_heads / heads;
+  const int64_t q_head_idx = hv_idx / head_ratio;
+
+  float q_norm = 0.0f;
+  float k_norm = 0.0f;
+  if (use_qk_l2norm_in_kernel) {
+    for (int64_t k_idx = 0; k_idx < key_dim; ++k_idx) {
+      const float q_val = static_cast<float>(
+          q[token_idx * q_stride_t + q_head_idx * q_stride_h +
+            k_idx * q_stride_k]);
+      const float k_val = static_cast<float>(
+          k[token_idx * k_stride_t + q_head_idx * k_stride_h +
+            k_idx * k_stride_k]);
+      q_norm += q_val * q_val;
+      k_norm += k_val * k_val;
+    }
+    q_norm = rsqrtf(q_norm + 1e-6f);
+    k_norm = rsqrtf(k_norm + 1e-6f);
+  } else {
+    q_norm = 1.0f;
+    k_norm = 1.0f;
+  }
+
+  const float x = static_cast<float>(
+                      a[token_idx * a_stride_t + hv_idx * a_stride_h]) +
+                  static_cast<float>(dt_bias[hv_idx]);
+  const float beta_x = static_cast<float>(beta) * x;
+  const float softplus_x =
+      beta_x <= static_cast<float>(threshold)
+          ? static_cast<float>(1.0 / beta) * log1pf(expf(beta_x))
+          : x;
+  const float g =
+      -expf(static_cast<float>(A_log[hv_idx])) * softplus_x;
+  const float beta_t =
+      1.0f / (1.0f + expf(-static_cast<float>(
+                            b[token_idx * b_stride_t + hv_idx * b_stride_h])));
+  const float decay = expf(g);
+
+  float state_dot_k = 0.0f;
+  for (int64_t k_idx = 0; k_idx < key_dim; ++k_idx) {
+    const float k_val =
+        static_cast<float>(k[token_idx * k_stride_t + q_head_idx * k_stride_h +
+                             k_idx * k_stride_k]) *
+        k_norm;
+    const int64_t state_offset =
+        token_idx * state_stride_t + hv_idx * state_stride_h +
+        value_idx * state_stride_v + k_idx * state_stride_k;
+    const float decayed_state = static_cast<float>(state[state_offset]) * decay;
+    state_dot_k += decayed_state * k_val;
+  }
+
+  const float v_residual =
+      (static_cast<float>(v[token_idx * v_stride_t + hv_idx * v_stride_h +
+                            value_idx * v_stride_v]) -
+       state_dot_k) *
+      beta_t;
+
+  float out_val = 0.0f;
+  for (int64_t k_idx = 0; k_idx < key_dim; ++k_idx) {
+    const float k_val =
+        static_cast<float>(k[token_idx * k_stride_t + q_head_idx * k_stride_h +
+                             k_idx * k_stride_k]) *
+        k_norm;
+    const int64_t state_offset =
+        token_idx * state_stride_t + hv_idx * state_stride_h +
+        value_idx * state_stride_v + k_idx * state_stride_k;
+    const float new_state =
+        static_cast<float>(state[state_offset]) * decay + v_residual * k_val;
+    state[state_offset] = static_cast<state_t>(new_state);
+
+    const float q_val =
+        static_cast<float>(q[token_idx * q_stride_t + q_head_idx * q_stride_h +
+                             k_idx * q_stride_k]) *
+        q_norm * static_cast<float>(scale);
+    out_val += new_state * q_val;
+  }
+
+  out[token_idx * out_stride_t + hv_idx * out_stride_h +
+      value_idx * out_stride_v] = static_cast<scalar_t>(out_val);
+}
+
+template <typename scalar_t, typename state_t>
+__global__ void fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kernel(
+    const scalar_t* __restrict__ A_log, const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b, const scalar_t* __restrict__ dt_bias,
+    const scalar_t* __restrict__ q, const scalar_t* __restrict__ k,
+    const scalar_t* __restrict__ v, state_t* __restrict__ state,
+    const int32_t* __restrict__ state_indices, scalar_t* __restrict__ out,
+    int64_t tokens, int64_t heads, int64_t kv_heads, int64_t key_dim,
+    int64_t value_dim, int64_t q_stride_t, int64_t q_stride_h,
+    int64_t q_stride_k, int64_t k_stride_t, int64_t k_stride_h,
+    int64_t k_stride_k, int64_t v_stride_t, int64_t v_stride_h,
+    int64_t v_stride_v, int64_t a_stride_t, int64_t a_stride_h,
+    int64_t b_stride_t, int64_t b_stride_h, int64_t state_stride_slot,
+    int64_t state_stride_h, int64_t state_stride_v, int64_t state_stride_k,
+    int64_t indices_stride, int64_t out_stride_t, int64_t out_stride_h,
+    int64_t out_stride_v, double beta, double threshold, double scale,
+    bool use_qk_l2norm_in_kernel) {
+  const int64_t linear_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t total = tokens * kv_heads * value_dim;
+  if (linear_idx >= total) {
+    return;
+  }
+
+  const int64_t value_idx = linear_idx % value_dim;
+  const int64_t hv_idx = (linear_idx / value_dim) % kv_heads;
+  const int64_t token_idx = linear_idx / (value_dim * kv_heads);
+  const int64_t state_idx = state_indices[token_idx * indices_stride];
+  if (state_idx < 0) {
+    out[token_idx * out_stride_t + hv_idx * out_stride_h +
+        value_idx * out_stride_v] = static_cast<scalar_t>(0.0f);
+    return;
+  }
+  const int64_t head_ratio = kv_heads / heads;
+  const int64_t q_head_idx = hv_idx / head_ratio;
+
+  float q_norm = 0.0f;
+  float k_norm = 0.0f;
+  if (use_qk_l2norm_in_kernel) {
+    for (int64_t k_idx = 0; k_idx < key_dim; ++k_idx) {
+      const float q_val = static_cast<float>(
+          q[token_idx * q_stride_t + q_head_idx * q_stride_h +
+            k_idx * q_stride_k]);
+      const float k_val = static_cast<float>(
+          k[token_idx * k_stride_t + q_head_idx * k_stride_h +
+            k_idx * k_stride_k]);
+      q_norm += q_val * q_val;
+      k_norm += k_val * k_val;
+    }
+    q_norm = rsqrtf(q_norm + 1e-6f);
+    k_norm = rsqrtf(k_norm + 1e-6f);
+  } else {
+    q_norm = 1.0f;
+    k_norm = 1.0f;
+  }
+
+  const float x = static_cast<float>(
+                      a[token_idx * a_stride_t + hv_idx * a_stride_h]) +
+                  static_cast<float>(dt_bias[hv_idx]);
+  const float beta_x = static_cast<float>(beta) * x;
+  const float softplus_x =
+      beta_x <= static_cast<float>(threshold)
+          ? static_cast<float>(1.0 / beta) * log1pf(expf(beta_x))
+          : x;
+  const float g =
+      -expf(static_cast<float>(A_log[hv_idx])) * softplus_x;
+  const float beta_t =
+      1.0f / (1.0f + expf(-static_cast<float>(
+                            b[token_idx * b_stride_t + hv_idx * b_stride_h])));
+  const float decay = expf(g);
+
+  float state_dot_k = 0.0f;
+  for (int64_t k_idx = 0; k_idx < key_dim; ++k_idx) {
+    const float k_val =
+        static_cast<float>(k[token_idx * k_stride_t + q_head_idx * k_stride_h +
+                             k_idx * k_stride_k]) *
+        k_norm;
+    const int64_t state_offset =
+        state_idx * state_stride_slot + hv_idx * state_stride_h +
+        value_idx * state_stride_v + k_idx * state_stride_k;
+    const float decayed_state = static_cast<float>(state[state_offset]) * decay;
+    state_dot_k += decayed_state * k_val;
+  }
+
+  const float v_residual =
+      (static_cast<float>(v[token_idx * v_stride_t + hv_idx * v_stride_h +
+                            value_idx * v_stride_v]) -
+       state_dot_k) *
+      beta_t;
+
+  float out_val = 0.0f;
+  for (int64_t k_idx = 0; k_idx < key_dim; ++k_idx) {
+    const float k_val =
+        static_cast<float>(k[token_idx * k_stride_t + q_head_idx * k_stride_h +
+                             k_idx * k_stride_k]) *
+        k_norm;
+    const int64_t state_offset =
+        state_idx * state_stride_slot + hv_idx * state_stride_h +
+        value_idx * state_stride_v + k_idx * state_stride_k;
+    const float new_state =
+        static_cast<float>(state[state_offset]) * decay + v_residual * k_val;
+    state[state_offset] = static_cast<state_t>(new_state);
+
+    const float q_val =
+        static_cast<float>(q[token_idx * q_stride_t + q_head_idx * q_stride_h +
+                             k_idx * q_stride_k]) *
+        q_norm * static_cast<float>(scale);
+    out_val += new_state * q_val;
+  }
+
+  out[token_idx * out_stride_t + hv_idx * out_stride_h +
+      value_idx * out_stride_v] = static_cast<scalar_t>(out_val);
+}
+
+template <typename scalar_t, typename state_t>
+__global__ void fused_recurrent_gated_delta_rule_gfx906_packed_decode_kernel(
+    const scalar_t* __restrict__ mixed_qkv, const scalar_t* __restrict__ a,
+    const scalar_t* __restrict__ b, const scalar_t* __restrict__ A_log,
+    const scalar_t* __restrict__ dt_bias, state_t* __restrict__ state,
+    const int32_t* __restrict__ state_indices, scalar_t* __restrict__ out,
+    int64_t tokens, int64_t heads, int64_t kv_heads, int64_t key_dim,
+    int64_t value_dim, int64_t mixed_stride_t, int64_t mixed_stride_d,
+    int64_t a_stride_t, int64_t a_stride_h, int64_t b_stride_t,
+    int64_t b_stride_h, int64_t state_stride_slot, int64_t state_stride_h,
+    int64_t state_stride_v, int64_t state_stride_k, int64_t indices_stride,
+    int64_t out_stride_t, int64_t out_stride_one, int64_t out_stride_h,
+    int64_t out_stride_v, double scale, bool use_qk_l2norm_in_kernel,
+    bool use_tiled_qk_head_mapping) {
+  const int64_t linear_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t total = tokens * kv_heads * value_dim;
+  if (linear_idx >= total) {
+    return;
+  }
+
+  const int64_t value_idx = linear_idx % value_dim;
+  const int64_t hv_idx = (linear_idx / value_dim) % kv_heads;
+  const int64_t token_idx = linear_idx / (value_dim * kv_heads);
+  const int64_t state_idx = state_indices[token_idx * indices_stride];
+  constexpr int shared_norm_width = 128;
+  const bool use_shared_qk_norm =
+      use_qk_l2norm_in_kernel && key_dim == shared_norm_width &&
+      value_dim == shared_norm_width &&
+      blockDim.x == 2 * shared_norm_width && total % blockDim.x == 0;
+  if (state_idx < 0 && !use_shared_qk_norm) {
+    out[token_idx * out_stride_t + hv_idx * out_stride_h +
+        value_idx * out_stride_v] = static_cast<scalar_t>(0.0f);
+    return;
+  }
+
+  const int64_t head_ratio = kv_heads / heads;
+  const int64_t q_head_idx =
+      use_tiled_qk_head_mapping ? (hv_idx % heads) : (hv_idx / head_ratio);
+  const int64_t q_offset = q_head_idx * key_dim;
+  const int64_t k_offset = heads * key_dim + q_head_idx * key_dim;
+  const int64_t v_offset = 2 * heads * key_dim + hv_idx * value_dim;
+
+  float q_norm = 0.0f;
+  float k_norm = 0.0f;
+  __shared__ float q_norm_sums[2 * shared_norm_width];
+  __shared__ float k_norm_sums[2 * shared_norm_width];
+  __shared__ float q_shared[2 * shared_norm_width];
+  __shared__ float k_shared[2 * shared_norm_width];
+  __shared__ float q_norm_scales[2];
+  __shared__ float k_norm_scales[2];
+  if (use_qk_l2norm_in_kernel) {
+    if (use_shared_qk_norm) {
+      const int64_t group_idx = threadIdx.x / shared_norm_width;
+      const int64_t group_lane = threadIdx.x - group_idx * shared_norm_width;
+      const int64_t group_linear_idx =
+          blockIdx.x * blockDim.x + group_idx * shared_norm_width;
+      const int64_t group_hv_idx =
+          (group_linear_idx / value_dim) % kv_heads;
+      const int64_t group_token_idx =
+          group_linear_idx / (value_dim * kv_heads);
+      const int64_t group_q_head_idx =
+          use_tiled_qk_head_mapping ? (group_hv_idx % heads)
+                                    : (group_hv_idx / head_ratio);
+      const int64_t group_q_offset = group_q_head_idx * key_dim;
+      const int64_t group_k_offset =
+          heads * key_dim + group_q_head_idx * key_dim;
+
+      const float q_val = static_cast<float>(
+          mixed_qkv[group_token_idx * mixed_stride_t +
+                    (group_q_offset + group_lane) * mixed_stride_d]);
+      const float k_val = static_cast<float>(
+          mixed_qkv[group_token_idx * mixed_stride_t +
+                    (group_k_offset + group_lane) * mixed_stride_d]);
+      const int64_t shared_offset = group_idx * shared_norm_width + group_lane;
+      q_shared[shared_offset] = q_val;
+      k_shared[shared_offset] = k_val;
+      q_norm_sums[shared_offset] = q_val * q_val;
+      k_norm_sums[shared_offset] = k_val * k_val;
+      __syncthreads();
+
+      for (int stride = shared_norm_width / 2; stride > 0; stride >>= 1) {
+        if (group_lane < stride) {
+          q_norm_sums[shared_offset] += q_norm_sums[shared_offset + stride];
+          k_norm_sums[shared_offset] += k_norm_sums[shared_offset + stride];
+        }
+        __syncthreads();
+      }
+
+      if (group_lane == 0) {
+        q_norm_scales[group_idx] =
+            rsqrtf(q_norm_sums[group_idx * shared_norm_width] + 1e-6f);
+        k_norm_scales[group_idx] =
+            rsqrtf(k_norm_sums[group_idx * shared_norm_width] + 1e-6f);
+      }
+      __syncthreads();
+
+      q_norm = q_norm_scales[group_idx];
+      k_norm = k_norm_scales[group_idx];
+      q_shared[shared_offset] = q_val * q_norm * static_cast<float>(scale);
+      k_shared[shared_offset] = k_val * k_norm;
+      __syncthreads();
+    } else {
+      for (int64_t k_idx = 0; k_idx < key_dim; ++k_idx) {
+        const float q_val = static_cast<float>(
+            mixed_qkv[token_idx * mixed_stride_t +
+                      (q_offset + k_idx) * mixed_stride_d]);
+        const float k_val = static_cast<float>(
+            mixed_qkv[token_idx * mixed_stride_t +
+                      (k_offset + k_idx) * mixed_stride_d]);
+        q_norm += q_val * q_val;
+        k_norm += k_val * k_val;
+      }
+      q_norm = rsqrtf(q_norm + 1e-6f);
+      k_norm = rsqrtf(k_norm + 1e-6f);
+    }
+  } else {
+    q_norm = 1.0f;
+    k_norm = 1.0f;
+  }
+
+  if (state_idx < 0) {
+    out[token_idx * out_stride_t + hv_idx * out_stride_h +
+        value_idx * out_stride_v] = static_cast<scalar_t>(0.0f);
+    return;
+  }
+
+  const float x = static_cast<float>(
+                      a[token_idx * a_stride_t + hv_idx * a_stride_h]) +
+                  static_cast<float>(dt_bias[hv_idx]);
+  const float softplus_x = x <= 20.0f ? log1pf(expf(x)) : x;
+  const float g =
+      -expf(static_cast<float>(A_log[hv_idx])) * softplus_x;
+  const float beta_t =
+      1.0f / (1.0f + expf(-static_cast<float>(
+                            b[token_idx * b_stride_t + hv_idx * b_stride_h])));
+  const float decay = expf(g);
+
+  float state_dot_k = 0.0f;
+  for (int64_t k_idx = 0; k_idx < key_dim; ++k_idx) {
+    const float k_val =
+        use_shared_qk_norm
+            ? k_shared[(threadIdx.x / shared_norm_width) * shared_norm_width +
+                       k_idx]
+            : static_cast<float>(
+                  mixed_qkv[token_idx * mixed_stride_t +
+                            (k_offset + k_idx) * mixed_stride_d]) *
+                  k_norm;
+    const int64_t state_offset =
+        state_idx * state_stride_slot + hv_idx * state_stride_h +
+        value_idx * state_stride_v + k_idx * state_stride_k;
+    const float decayed_state = static_cast<float>(state[state_offset]) * decay;
+    state_dot_k += decayed_state * k_val;
+  }
+
+  const float v_val = static_cast<float>(
+      mixed_qkv[token_idx * mixed_stride_t +
+                (v_offset + value_idx) * mixed_stride_d]);
+  const float v_residual = (v_val - state_dot_k) * beta_t;
+
+  float out_val = 0.0f;
+  for (int64_t k_idx = 0; k_idx < key_dim; ++k_idx) {
+    const float k_val =
+        use_shared_qk_norm
+            ? k_shared[(threadIdx.x / shared_norm_width) * shared_norm_width +
+                       k_idx]
+            : static_cast<float>(
+                  mixed_qkv[token_idx * mixed_stride_t +
+                            (k_offset + k_idx) * mixed_stride_d]) *
+                  k_norm;
+    const int64_t state_offset =
+        state_idx * state_stride_slot + hv_idx * state_stride_h +
+        value_idx * state_stride_v + k_idx * state_stride_k;
+    const float new_state =
+        static_cast<float>(state[state_offset]) * decay + v_residual * k_val;
+    state[state_offset] = static_cast<state_t>(new_state);
+
+    const float q_val =
+        use_shared_qk_norm
+            ? q_shared[(threadIdx.x / shared_norm_width) * shared_norm_width +
+                       k_idx]
+            : static_cast<float>(
+                  mixed_qkv[token_idx * mixed_stride_t +
+                            (q_offset + k_idx) * mixed_stride_d]) *
+                  q_norm * static_cast<float>(scale);
+    out_val += new_state * q_val;
+  }
+
+  out[token_idx * out_stride_t + 0 * out_stride_one + hv_idx * out_stride_h +
+      value_idx * out_stride_v] = static_cast<scalar_t>(out_val);
+}
+
+}  // namespace
+
+torch::Tensor causal_conv1d_gfx906_decode_update(
+    torch::Tensor x, torch::Tensor conv_state, torch::Tensor weight,
+    std::optional<torch::Tensor> bias,
+    std::optional<torch::Tensor> conv_state_indices, int64_t pad_slot_id,
+    bool silu_activation) {
+  TORCH_CHECK(x.is_cuda(), "x must be a CUDA tensor");
+  TORCH_CHECK(conv_state.is_cuda(), "conv_state must be a CUDA tensor");
+  TORCH_CHECK(weight.is_cuda(), "weight must be a CUDA tensor");
+  TORCH_CHECK(x.dim() == 2, "x must have shape [batch, dim]");
+  TORCH_CHECK(conv_state.dim() == 3,
+              "conv_state must have shape [cache, dim, state_len]");
+  TORCH_CHECK(weight.dim() == 2, "weight must have shape [dim, width]");
+  TORCH_CHECK(x.scalar_type() == weight.scalar_type(),
+              "x and weight must have the same dtype");
+  TORCH_CHECK(conv_state.scalar_type() == x.scalar_type() ||
+                  conv_state.scalar_type() == at::ScalarType::Float,
+              "conv_state must have the same dtype as x or be float32");
+  TORCH_CHECK(x.size(1) == conv_state.size(1),
+              "x dim must match conv_state dim");
+  TORCH_CHECK(x.size(1) == weight.size(0), "x dim must match weight dim");
+  TORCH_CHECK(conv_state.size(2) >= weight.size(1) - 1,
+              "conv_state is shorter than convolution width - 1");
+  if (bias.has_value()) {
+    TORCH_CHECK(bias->is_cuda(), "bias must be a CUDA tensor");
+    TORCH_CHECK(bias->scalar_type() == x.scalar_type(),
+                "bias must have the same dtype as x");
+    TORCH_CHECK(bias->numel() == x.size(1), "bias shape must be [dim]");
+  }
+  if (conv_state_indices.has_value()) {
+    TORCH_CHECK(conv_state_indices->is_cuda(),
+                "conv_state_indices must be a CUDA tensor");
+    TORCH_CHECK(conv_state_indices->scalar_type() == at::ScalarType::Int,
+                "conv_state_indices must be int32");
+    TORCH_CHECK(conv_state_indices->numel() == x.size(0),
+                "conv_state_indices shape must be [batch]");
+  }
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
+  auto out = torch::empty_like(x);
+  const int64_t batch = x.size(0);
+  const int64_t dim = x.size(1);
+  const int64_t total = batch * dim;
+  const int threads = 256;
+  const int blocks = static_cast<int>((total + threads - 1) / threads);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+  if (conv_state.scalar_type() == at::ScalarType::Float) {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        x.scalar_type(), "causal_conv1d_gfx906_decode_update", [&] {
+          causal_conv1d_gfx906_decode_update_kernel<scalar_t, float>
+              <<<blocks, threads, 0, stream>>>(
+                  x.data_ptr<scalar_t>(), conv_state.data_ptr<float>(),
+                  weight.data_ptr<scalar_t>(),
+                  bias.has_value() ? bias->data_ptr<scalar_t>() : nullptr,
+                  conv_state_indices.has_value()
+                      ? conv_state_indices->data_ptr<int32_t>()
+                      : nullptr,
+                  out.data_ptr<scalar_t>(), batch, dim, weight.size(1),
+                  conv_state.size(2), x.stride(0), x.stride(1),
+                  conv_state.stride(0), conv_state.stride(1),
+                  conv_state.stride(2), weight.stride(0), weight.stride(1),
+                  out.stride(0), out.stride(1), pad_slot_id, bias.has_value(),
+                  silu_activation);
+        });
+  } else {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        x.scalar_type(), "causal_conv1d_gfx906_decode_update", [&] {
+          causal_conv1d_gfx906_decode_update_kernel<scalar_t, scalar_t>
+              <<<blocks, threads, 0, stream>>>(
+                  x.data_ptr<scalar_t>(), conv_state.data_ptr<scalar_t>(),
+                  weight.data_ptr<scalar_t>(),
+                  bias.has_value() ? bias->data_ptr<scalar_t>() : nullptr,
+                  conv_state_indices.has_value()
+                      ? conv_state_indices->data_ptr<int32_t>()
+                      : nullptr,
+                  out.data_ptr<scalar_t>(), batch, dim, weight.size(1),
+                  conv_state.size(2), x.stride(0), x.stride(1),
+                  conv_state.stride(0), conv_state.stride(1),
+                  conv_state.stride(2), weight.stride(0), weight.stride(1),
+                  out.stride(0), out.stride(1), pad_slot_id, bias.has_value(),
+                  silu_activation);
+        });
+  }
+  return out;
+}
+
+torch::Tensor fused_sigmoid_gating_delta_rule_gfx906_decode(
+    torch::Tensor A_log, torch::Tensor a, torch::Tensor b, torch::Tensor dt_bias,
+    torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor state,
+    double beta, double threshold, double scale,
+    bool use_qk_l2norm_in_kernel) {
+  TORCH_CHECK(q.is_cuda(), "q must be a CUDA tensor");
+  TORCH_CHECK(k.is_cuda(), "k must be a CUDA tensor");
+  TORCH_CHECK(v.is_cuda(), "v must be a CUDA tensor");
+  TORCH_CHECK(state.is_cuda(), "state must be a CUDA tensor");
+  TORCH_CHECK(q.dim() == 4 && q.size(0) == 1,
+              "q must have shape [1, tokens, heads, key_dim]");
+  TORCH_CHECK(k.dim() == 4 && k.size(0) == 1,
+              "k must have shape [1, tokens, heads, key_dim]");
+  TORCH_CHECK(v.dim() == 4 && v.size(0) == 1,
+              "v must have shape [1, tokens, kv_heads, value_dim]");
+  TORCH_CHECK(state.dim() == 4,
+              "state must have shape [tokens, kv_heads, value_dim, key_dim]");
+  TORCH_CHECK(q.scalar_type() == k.scalar_type() && q.scalar_type() == v.scalar_type(),
+              "q, k, and v must have the same dtype");
+  TORCH_CHECK(state.scalar_type() == q.scalar_type() ||
+                  state.scalar_type() == at::ScalarType::Float,
+              "state must have the same dtype as q or be float32");
+  TORCH_CHECK(A_log.scalar_type() == q.scalar_type() &&
+                  a.scalar_type() == q.scalar_type() &&
+                  b.scalar_type() == q.scalar_type() &&
+                  dt_bias.scalar_type() == q.scalar_type(),
+              "A_log, a, b, dt_bias, q, k, and v must have the same dtype");
+  TORCH_CHECK(q.size(1) == k.size(1) && q.size(1) == v.size(1),
+              "q, k, and v token counts must match");
+  TORCH_CHECK(q.size(2) == k.size(2), "q and k head counts must match");
+  TORCH_CHECK(q.size(3) == k.size(3), "q and k key dims must match");
+  TORCH_CHECK(v.size(2) % q.size(2) == 0,
+              "kv_heads must be divisible by heads");
+  TORCH_CHECK(state.size(0) >= q.size(1), "state token dim is too small");
+  TORCH_CHECK(state.size(1) == v.size(2), "state kv_heads mismatch");
+  TORCH_CHECK(state.size(2) == v.size(3), "state value_dim mismatch");
+  TORCH_CHECK(state.size(3) == q.size(3), "state key_dim mismatch");
+  TORCH_CHECK(A_log.numel() == v.size(2), "A_log shape must be [kv_heads]");
+  TORCH_CHECK(dt_bias.numel() == v.size(2), "dt_bias shape must be [kv_heads]");
+  if (a.dim() == 2) {
+    TORCH_CHECK(a.size(0) == q.size(1) && a.size(1) == v.size(2),
+                "a shape must be [tokens, kv_heads]");
+  } else {
+    TORCH_CHECK(a.dim() == 3 && a.size(0) == 1 && a.size(1) == q.size(1) &&
+                    a.size(2) == v.size(2),
+                "a shape must be [tokens, kv_heads] or [1, tokens, kv_heads]");
+  }
+  if (b.dim() == 2) {
+    TORCH_CHECK(b.size(0) == q.size(1) && b.size(1) == v.size(2),
+                "b shape must be [tokens, kv_heads]");
+  } else {
+    TORCH_CHECK(b.dim() == 3 && b.size(0) == 1 && b.size(1) == q.size(1) &&
+                    b.size(2) == v.size(2),
+                "b shape must be [tokens, kv_heads] or [1, tokens, kv_heads]");
+  }
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(q));
+  const int64_t tokens = q.size(1);
+  const int64_t heads = q.size(2);
+  const int64_t kv_heads = v.size(2);
+  const int64_t key_dim = q.size(3);
+  const int64_t value_dim = v.size(3);
+  auto out = torch::empty({1, tokens, kv_heads, value_dim}, q.options());
+  const int64_t total = tokens * kv_heads * value_dim;
+  const int threads = 256;
+  const int blocks = static_cast<int>((total + threads - 1) / threads);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+  const torch::Tensor a_view = a.dim() == 2 ? a : a.squeeze(0);
+  const torch::Tensor b_view = b.dim() == 2 ? b : b.squeeze(0);
+
+  if (state.scalar_type() == at::ScalarType::Float) {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        q.scalar_type(), "fused_sigmoid_gating_delta_rule_gfx906_decode", [&] {
+          fused_sigmoid_gating_delta_rule_gfx906_decode_kernel<scalar_t, float>
+              <<<blocks, threads, 0, stream>>>(
+                  A_log.data_ptr<scalar_t>(), a_view.data_ptr<scalar_t>(),
+                  b_view.data_ptr<scalar_t>(), dt_bias.data_ptr<scalar_t>(),
+                  q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(),
+                  v.data_ptr<scalar_t>(), state.data_ptr<float>(),
+                  out.data_ptr<scalar_t>(), tokens, heads, kv_heads, key_dim,
+                  value_dim, q.stride(1), q.stride(2), q.stride(3),
+                  k.stride(1), k.stride(2), k.stride(3), v.stride(1),
+                  v.stride(2), v.stride(3), a_view.stride(0),
+                  a_view.stride(1), b_view.stride(0), b_view.stride(1),
+                  state.stride(0), state.stride(1), state.stride(2),
+                  state.stride(3), out.stride(1), out.stride(2),
+                  out.stride(3), beta, threshold, scale,
+                  use_qk_l2norm_in_kernel);
+        });
+  } else {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        q.scalar_type(), "fused_sigmoid_gating_delta_rule_gfx906_decode", [&] {
+          fused_sigmoid_gating_delta_rule_gfx906_decode_kernel<scalar_t, scalar_t>
+              <<<blocks, threads, 0, stream>>>(
+                  A_log.data_ptr<scalar_t>(), a_view.data_ptr<scalar_t>(),
+                  b_view.data_ptr<scalar_t>(), dt_bias.data_ptr<scalar_t>(),
+                  q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(),
+                  v.data_ptr<scalar_t>(), state.data_ptr<scalar_t>(),
+                  out.data_ptr<scalar_t>(), tokens, heads, kv_heads, key_dim,
+                  value_dim, q.stride(1), q.stride(2), q.stride(3),
+                  k.stride(1), k.stride(2), k.stride(3), v.stride(1),
+                  v.stride(2), v.stride(3), a_view.stride(0),
+                  a_view.stride(1), b_view.stride(0), b_view.stride(1),
+                  state.stride(0), state.stride(1), state.stride(2),
+                  state.stride(3), out.stride(1), out.stride(2),
+                  out.stride(3), beta, threshold, scale,
+                  use_qk_l2norm_in_kernel);
+        });
+  }
+  return out;
+}
+
+torch::Tensor fused_sigmoid_gating_delta_rule_gfx906_indexed_decode(
+    torch::Tensor A_log, torch::Tensor a, torch::Tensor b, torch::Tensor dt_bias,
+    torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor state,
+    torch::Tensor state_indices, double beta, double threshold, double scale,
+    bool use_qk_l2norm_in_kernel) {
+  TORCH_CHECK(q.is_cuda(), "q must be a CUDA tensor");
+  TORCH_CHECK(k.is_cuda(), "k must be a CUDA tensor");
+  TORCH_CHECK(v.is_cuda(), "v must be a CUDA tensor");
+  TORCH_CHECK(state.is_cuda(), "state must be a CUDA tensor");
+  TORCH_CHECK(state_indices.is_cuda(), "state_indices must be a CUDA tensor");
+  TORCH_CHECK(q.dim() == 4 && q.size(0) == 1,
+              "q must have shape [1, tokens, heads, key_dim]");
+  TORCH_CHECK(k.dim() == 4 && k.size(0) == 1,
+              "k must have shape [1, tokens, heads, key_dim]");
+  TORCH_CHECK(v.dim() == 4 && v.size(0) == 1,
+              "v must have shape [1, tokens, kv_heads, value_dim]");
+  TORCH_CHECK(state.dim() == 4,
+              "state must have shape [slots, kv_heads, value_dim, key_dim]");
+  TORCH_CHECK(state_indices.dim() == 1, "state_indices must have shape [tokens]");
+  TORCH_CHECK(state_indices.scalar_type() == at::ScalarType::Int,
+              "state_indices must be int32");
+  TORCH_CHECK(q.scalar_type() == k.scalar_type() && q.scalar_type() == v.scalar_type(),
+              "q, k, and v must have the same dtype");
+  TORCH_CHECK(state.scalar_type() == q.scalar_type() ||
+                  state.scalar_type() == at::ScalarType::Float,
+              "state must have the same dtype as q or be float32");
+  TORCH_CHECK(A_log.scalar_type() == q.scalar_type() &&
+                  a.scalar_type() == q.scalar_type() &&
+                  b.scalar_type() == q.scalar_type() &&
+                  dt_bias.scalar_type() == q.scalar_type(),
+              "A_log, a, b, dt_bias, q, k, and v must have the same dtype");
+  TORCH_CHECK(q.size(1) == k.size(1) && q.size(1) == v.size(1),
+              "q, k, and v token counts must match");
+  TORCH_CHECK(state_indices.numel() == q.size(1),
+              "state_indices shape must be [tokens]");
+  TORCH_CHECK(q.size(2) == k.size(2), "q and k head counts must match");
+  TORCH_CHECK(q.size(3) == k.size(3), "q and k key dims must match");
+  TORCH_CHECK(v.size(2) % q.size(2) == 0,
+              "kv_heads must be divisible by heads");
+  TORCH_CHECK(state.size(1) == v.size(2), "state kv_heads mismatch");
+  TORCH_CHECK(state.size(2) == v.size(3), "state value_dim mismatch");
+  TORCH_CHECK(state.size(3) == q.size(3), "state key_dim mismatch");
+  TORCH_CHECK(A_log.numel() == v.size(2), "A_log shape must be [kv_heads]");
+  TORCH_CHECK(dt_bias.numel() == v.size(2), "dt_bias shape must be [kv_heads]");
+  if (a.dim() == 2) {
+    TORCH_CHECK(a.size(0) == q.size(1) && a.size(1) == v.size(2),
+                "a shape must be [tokens, kv_heads]");
+  } else {
+    TORCH_CHECK(a.dim() == 3 && a.size(0) == 1 && a.size(1) == q.size(1) &&
+                    a.size(2) == v.size(2),
+                "a shape must be [tokens, kv_heads] or [1, tokens, kv_heads]");
+  }
+  if (b.dim() == 2) {
+    TORCH_CHECK(b.size(0) == q.size(1) && b.size(1) == v.size(2),
+                "b shape must be [tokens, kv_heads]");
+  } else {
+    TORCH_CHECK(b.dim() == 3 && b.size(0) == 1 && b.size(1) == q.size(1) &&
+                    b.size(2) == v.size(2),
+                "b shape must be [tokens, kv_heads] or [1, tokens, kv_heads]");
+  }
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(q));
+  const int64_t tokens = q.size(1);
+  const int64_t heads = q.size(2);
+  const int64_t kv_heads = v.size(2);
+  const int64_t key_dim = q.size(3);
+  const int64_t value_dim = v.size(3);
+  auto out = torch::empty({1, tokens, kv_heads, value_dim}, q.options());
+  const int64_t total = tokens * kv_heads * value_dim;
+  const int threads = 256;
+  const int blocks = static_cast<int>((total + threads - 1) / threads);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+  const torch::Tensor a_view = a.dim() == 2 ? a : a.squeeze(0);
+  const torch::Tensor b_view = b.dim() == 2 ? b : b.squeeze(0);
+
+  if (state.scalar_type() == at::ScalarType::Float) {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        q.scalar_type(), "fused_sigmoid_gating_delta_rule_gfx906_indexed_decode", [&] {
+          fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kernel<scalar_t, float>
+              <<<blocks, threads, 0, stream>>>(
+                  A_log.data_ptr<scalar_t>(), a_view.data_ptr<scalar_t>(),
+                  b_view.data_ptr<scalar_t>(), dt_bias.data_ptr<scalar_t>(),
+                  q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(),
+                  v.data_ptr<scalar_t>(), state.data_ptr<float>(),
+                  state_indices.data_ptr<int32_t>(), out.data_ptr<scalar_t>(),
+                  tokens, heads, kv_heads, key_dim, value_dim, q.stride(1),
+                  q.stride(2), q.stride(3), k.stride(1), k.stride(2),
+                  k.stride(3), v.stride(1), v.stride(2), v.stride(3),
+                  a_view.stride(0), a_view.stride(1), b_view.stride(0),
+                  b_view.stride(1), state.stride(0), state.stride(1),
+                  state.stride(2), state.stride(3), state_indices.stride(0),
+                  out.stride(1), out.stride(2), out.stride(3), beta,
+                  threshold, scale, use_qk_l2norm_in_kernel);
+        });
+  } else {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        q.scalar_type(), "fused_sigmoid_gating_delta_rule_gfx906_indexed_decode", [&] {
+          fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kernel<scalar_t,
+                                                                       scalar_t>
+              <<<blocks, threads, 0, stream>>>(
+                  A_log.data_ptr<scalar_t>(), a_view.data_ptr<scalar_t>(),
+                  b_view.data_ptr<scalar_t>(), dt_bias.data_ptr<scalar_t>(),
+                  q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(),
+                  v.data_ptr<scalar_t>(), state.data_ptr<scalar_t>(),
+                  state_indices.data_ptr<int32_t>(), out.data_ptr<scalar_t>(),
+                  tokens, heads, kv_heads, key_dim, value_dim, q.stride(1),
+                  q.stride(2), q.stride(3), k.stride(1), k.stride(2),
+                  k.stride(3), v.stride(1), v.stride(2), v.stride(3),
+                  a_view.stride(0), a_view.stride(1), b_view.stride(0),
+                  b_view.stride(1), state.stride(0), state.stride(1),
+                  state.stride(2), state.stride(3), state_indices.stride(0),
+                  out.stride(1), out.stride(2), out.stride(3), beta,
+                  threshold, scale, use_qk_l2norm_in_kernel);
+        });
+  }
+  return out;
+}
+
+torch::Tensor fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state(
+    torch::Tensor A_log, torch::Tensor a, torch::Tensor b, torch::Tensor dt_bias,
+    torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor state,
+    torch::Tensor state_indices, double beta, double threshold, double scale,
+    bool use_qk_l2norm_in_kernel) {
+  TORCH_CHECK(q.is_cuda(), "q must be a CUDA tensor");
+  TORCH_CHECK(k.is_cuda(), "k must be a CUDA tensor");
+  TORCH_CHECK(v.is_cuda(), "v must be a CUDA tensor");
+  TORCH_CHECK(state.is_cuda(), "state must be a CUDA tensor");
+  TORCH_CHECK(state_indices.is_cuda(), "state_indices must be a CUDA tensor");
+  TORCH_CHECK(q.dim() == 4 && q.size(0) == 1,
+              "q must have shape [1, tokens, heads, key_dim]");
+  TORCH_CHECK(k.dim() == 4 && k.size(0) == 1,
+              "k must have shape [1, tokens, heads, key_dim]");
+  TORCH_CHECK(v.dim() == 4 && v.size(0) == 1,
+              "v must have shape [1, tokens, kv_heads, value_dim]");
+  TORCH_CHECK(state.dim() == 4,
+              "state must have shape [slots, kv_heads, key_dim, value_dim]");
+  TORCH_CHECK(state_indices.dim() == 1, "state_indices must have shape [tokens]");
+  TORCH_CHECK(state_indices.scalar_type() == at::ScalarType::Int,
+              "state_indices must be int32");
+  TORCH_CHECK(q.scalar_type() == k.scalar_type() && q.scalar_type() == v.scalar_type(),
+              "q, k, and v must have the same dtype");
+  TORCH_CHECK(state.scalar_type() == q.scalar_type() ||
+                  state.scalar_type() == at::ScalarType::Float,
+              "state must have the same dtype as q or be float32");
+  TORCH_CHECK(A_log.scalar_type() == q.scalar_type() &&
+                  a.scalar_type() == q.scalar_type() &&
+                  b.scalar_type() == q.scalar_type() &&
+                  dt_bias.scalar_type() == q.scalar_type(),
+              "A_log, a, b, dt_bias, q, k, and v must have the same dtype");
+  TORCH_CHECK(q.size(1) == k.size(1) && q.size(1) == v.size(1),
+              "q, k, and v token counts must match");
+  TORCH_CHECK(state_indices.numel() == q.size(1),
+              "state_indices shape must be [tokens]");
+  TORCH_CHECK(q.size(2) == k.size(2), "q and k head counts must match");
+  TORCH_CHECK(q.size(3) == k.size(3), "q and k key dims must match");
+  TORCH_CHECK(v.size(2) % q.size(2) == 0,
+              "kv_heads must be divisible by heads");
+  TORCH_CHECK(state.size(1) == v.size(2), "state kv_heads mismatch");
+  TORCH_CHECK(state.size(2) == q.size(3), "state key_dim mismatch");
+  TORCH_CHECK(state.size(3) == v.size(3), "state value_dim mismatch");
+  TORCH_CHECK(A_log.numel() == v.size(2), "A_log shape must be [kv_heads]");
+  TORCH_CHECK(dt_bias.numel() == v.size(2), "dt_bias shape must be [kv_heads]");
+  if (a.dim() == 2) {
+    TORCH_CHECK(a.size(0) == q.size(1) && a.size(1) == v.size(2),
+                "a shape must be [tokens, kv_heads]");
+  } else {
+    TORCH_CHECK(a.dim() == 3 && a.size(0) == 1 && a.size(1) == q.size(1) &&
+                    a.size(2) == v.size(2),
+                "a shape must be [tokens, kv_heads] or [1, tokens, kv_heads]");
+  }
+  if (b.dim() == 2) {
+    TORCH_CHECK(b.size(0) == q.size(1) && b.size(1) == v.size(2),
+                "b shape must be [tokens, kv_heads]");
+  } else {
+    TORCH_CHECK(b.dim() == 3 && b.size(0) == 1 && b.size(1) == q.size(1) &&
+                    b.size(2) == v.size(2),
+                "b shape must be [tokens, kv_heads] or [1, tokens, kv_heads]");
+  }
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(q));
+  const int64_t tokens = q.size(1);
+  const int64_t heads = q.size(2);
+  const int64_t kv_heads = v.size(2);
+  const int64_t key_dim = q.size(3);
+  const int64_t value_dim = v.size(3);
+  auto out = torch::empty({1, tokens, kv_heads, value_dim}, q.options());
+  const int64_t total = tokens * kv_heads * value_dim;
+  const int threads = 256;
+  const int blocks = static_cast<int>((total + threads - 1) / threads);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+  const torch::Tensor a_view = a.dim() == 2 ? a : a.squeeze(0);
+  const torch::Tensor b_view = b.dim() == 2 ? b : b.squeeze(0);
+
+  if (state.scalar_type() == at::ScalarType::Float) {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        q.scalar_type(), "fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state", [&] {
+          fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kernel<scalar_t, float>
+              <<<blocks, threads, 0, stream>>>(
+                  A_log.data_ptr<scalar_t>(), a_view.data_ptr<scalar_t>(),
+                  b_view.data_ptr<scalar_t>(), dt_bias.data_ptr<scalar_t>(),
+                  q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(),
+                  v.data_ptr<scalar_t>(), state.data_ptr<float>(),
+                  state_indices.data_ptr<int32_t>(), out.data_ptr<scalar_t>(),
+                  tokens, heads, kv_heads, key_dim, value_dim, q.stride(1),
+                  q.stride(2), q.stride(3), k.stride(1), k.stride(2),
+                  k.stride(3), v.stride(1), v.stride(2), v.stride(3),
+                  a_view.stride(0), a_view.stride(1), b_view.stride(0),
+                  b_view.stride(1), state.stride(0), state.stride(1),
+                  state.stride(3), state.stride(2), state_indices.stride(0),
+                  out.stride(1), out.stride(2), out.stride(3), beta,
+                  threshold, scale, use_qk_l2norm_in_kernel);
+        });
+  } else {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        q.scalar_type(), "fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state", [&] {
+          fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kernel<scalar_t,
+                                                                       scalar_t>
+              <<<blocks, threads, 0, stream>>>(
+                  A_log.data_ptr<scalar_t>(), a_view.data_ptr<scalar_t>(),
+                  b_view.data_ptr<scalar_t>(), dt_bias.data_ptr<scalar_t>(),
+                  q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(),
+                  v.data_ptr<scalar_t>(), state.data_ptr<scalar_t>(),
+                  state_indices.data_ptr<int32_t>(), out.data_ptr<scalar_t>(),
+                  tokens, heads, kv_heads, key_dim, value_dim, q.stride(1),
+                  q.stride(2), q.stride(3), k.stride(1), k.stride(2),
+                  k.stride(3), v.stride(1), v.stride(2), v.stride(3),
+                  a_view.stride(0), a_view.stride(1), b_view.stride(0),
+                  b_view.stride(1), state.stride(0), state.stride(1),
+                  state.stride(3), state.stride(2), state_indices.stride(0),
+                  out.stride(1), out.stride(2), out.stride(3), beta,
+                  threshold, scale, use_qk_l2norm_in_kernel);
+        });
+  }
+  return out;
+}
+
+torch::Tensor fused_recurrent_gated_delta_rule_gfx906_packed_decode(
+    torch::Tensor mixed_qkv, torch::Tensor a, torch::Tensor b,
+    torch::Tensor A_log, torch::Tensor dt_bias, torch::Tensor state,
+    torch::Tensor out, torch::Tensor state_indices, double scale,
+    bool use_qk_l2norm_in_kernel, bool use_tiled_qk_head_mapping,
+    bool use_transposed_state) {
+  TORCH_CHECK(mixed_qkv.is_cuda(), "mixed_qkv must be a CUDA tensor");
+  TORCH_CHECK(a.is_cuda(), "a must be a CUDA tensor");
+  TORCH_CHECK(b.is_cuda(), "b must be a CUDA tensor");
+  TORCH_CHECK(A_log.is_cuda(), "A_log must be a CUDA tensor");
+  TORCH_CHECK(dt_bias.is_cuda(), "dt_bias must be a CUDA tensor");
+  TORCH_CHECK(state.is_cuda(), "state must be a CUDA tensor");
+  TORCH_CHECK(out.is_cuda(), "out must be a CUDA tensor");
+  TORCH_CHECK(state_indices.is_cuda(), "state_indices must be a CUDA tensor");
+  TORCH_CHECK(mixed_qkv.dim() == 2, "mixed_qkv must have shape [tokens, dim]");
+  TORCH_CHECK(a.dim() == 2 && b.dim() == 2, "a and b must have shape [tokens, heads]");
+  TORCH_CHECK(state.dim() == 4,
+              "state must have shape [slots, kv_heads, value_dim, key_dim]");
+  TORCH_CHECK(out.dim() == 4 && out.size(1) == 1,
+              "out must have shape [tokens, 1, kv_heads, value_dim]");
+  TORCH_CHECK(state_indices.dim() == 1, "state_indices must have shape [tokens]");
+  TORCH_CHECK(state_indices.scalar_type() == at::ScalarType::Int,
+              "state_indices must be int32");
+  TORCH_CHECK(mixed_qkv.scalar_type() == a.scalar_type() &&
+                  mixed_qkv.scalar_type() == b.scalar_type() &&
+                  mixed_qkv.scalar_type() == A_log.scalar_type() &&
+                  mixed_qkv.scalar_type() == dt_bias.scalar_type() &&
+                  mixed_qkv.scalar_type() == out.scalar_type(),
+              "mixed_qkv, a, b, A_log, dt_bias, and out must have the same dtype");
+  TORCH_CHECK(state.scalar_type() == mixed_qkv.scalar_type() ||
+                  state.scalar_type() == at::ScalarType::Float,
+              "state must have the same dtype as mixed_qkv or be float32");
+
+  const int64_t tokens = mixed_qkv.size(0);
+  const int64_t kv_heads = state.size(1);
+  const int64_t value_dim = state.size(2);
+  const int64_t key_dim = state.size(3);
+  TORCH_CHECK(!use_transposed_state || key_dim == value_dim,
+              "transposed packed GDN state requires key_dim == value_dim");
+  TORCH_CHECK(a.size(0) == tokens && b.size(0) == tokens,
+              "a and b token counts must match mixed_qkv");
+  TORCH_CHECK(a.size(1) == kv_heads && b.size(1) == kv_heads,
+              "a and b head counts must match state kv_heads");
+  TORCH_CHECK(A_log.numel() == kv_heads && dt_bias.numel() == kv_heads,
+              "A_log and dt_bias must have kv_heads elements");
+  TORCH_CHECK(out.size(0) == tokens && out.size(2) == kv_heads &&
+                  out.size(3) == value_dim,
+              "out shape mismatch");
+  TORCH_CHECK(state_indices.numel() == tokens,
+              "state_indices shape must be [tokens]");
+
+  const int64_t qkv_dim = mixed_qkv.size(1);
+  const int64_t qk_dim = qkv_dim - kv_heads * value_dim;
+  TORCH_CHECK(qk_dim > 0 && qk_dim % 2 == 0,
+              "Invalid packed mixed_qkv dimension");
+  const int64_t q_dim = qk_dim / 2;
+  TORCH_CHECK(q_dim % key_dim == 0,
+              "Packed q dimension must be divisible by key_dim");
+  const int64_t heads = q_dim / key_dim;
+  TORCH_CHECK(heads > 0 && kv_heads % heads == 0,
+              "Invalid packed GDN head configuration");
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(mixed_qkv));
+  const int64_t total = tokens * kv_heads * value_dim;
+  const int threads = 256;
+  const int blocks = static_cast<int>((total + threads - 1) / threads);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+  const int64_t state_stride_v =
+      use_transposed_state ? state.stride(3) : state.stride(2);
+  const int64_t state_stride_k =
+      use_transposed_state ? state.stride(2) : state.stride(3);
+
+  if (state.scalar_type() == at::ScalarType::Float) {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        mixed_qkv.scalar_type(),
+        "fused_recurrent_gated_delta_rule_gfx906_packed_decode", [&] {
+          fused_recurrent_gated_delta_rule_gfx906_packed_decode_kernel<scalar_t,
+                                                                       float>
+              <<<blocks, threads, 0, stream>>>(
+                  mixed_qkv.data_ptr<scalar_t>(), a.data_ptr<scalar_t>(),
+                  b.data_ptr<scalar_t>(), A_log.data_ptr<scalar_t>(),
+                  dt_bias.data_ptr<scalar_t>(), state.data_ptr<float>(),
+                  state_indices.data_ptr<int32_t>(), out.data_ptr<scalar_t>(),
+                  tokens, heads, kv_heads, key_dim, value_dim,
+                  mixed_qkv.stride(0), mixed_qkv.stride(1), a.stride(0),
+                  a.stride(1), b.stride(0), b.stride(1), state.stride(0),
+                  state.stride(1), state_stride_v, state_stride_k,
+                  state_indices.stride(0), out.stride(0), out.stride(1),
+                  out.stride(2), out.stride(3), scale,
+                  use_qk_l2norm_in_kernel, use_tiled_qk_head_mapping);
+        });
+  } else {
+    VLLM_DISPATCH_FLOATING_TYPES(
+        mixed_qkv.scalar_type(),
+        "fused_recurrent_gated_delta_rule_gfx906_packed_decode", [&] {
+          fused_recurrent_gated_delta_rule_gfx906_packed_decode_kernel<scalar_t,
+                                                                       scalar_t>
+              <<<blocks, threads, 0, stream>>>(
+                  mixed_qkv.data_ptr<scalar_t>(), a.data_ptr<scalar_t>(),
+                  b.data_ptr<scalar_t>(), A_log.data_ptr<scalar_t>(),
+                  dt_bias.data_ptr<scalar_t>(), state.data_ptr<scalar_t>(),
+                  state_indices.data_ptr<int32_t>(), out.data_ptr<scalar_t>(),
+                  tokens, heads, kv_heads, key_dim, value_dim,
+                  mixed_qkv.stride(0), mixed_qkv.stride(1), a.stride(0),
+                  a.stride(1), b.stride(0), b.stride(1), state.stride(0),
+                  state.stride(1), state_stride_v, state_stride_k,
+                  state_indices.stride(0), out.stride(0), out.stride(1),
+                  out.stride(2), out.stride(3), scale,
+                  use_qk_l2norm_in_kernel, use_tiled_qk_head_mapping);
+        });
+  }
+  return out;
+}

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -91,6 +91,17 @@ void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
 void fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
                         torch::Tensor& weight, double epsilon);
 
+torch::Tensor rms_norm_gated_gfx906(torch::Tensor input, torch::Tensor weight,
+                                    torch::Tensor gate, double epsilon,
+                                    bool norm_before_gate);
+
+torch::Tensor gemma_rms_norm_gfx906(torch::Tensor input, torch::Tensor weight,
+                                    double epsilon);
+
+std::vector<torch::Tensor> gemma_fused_add_rms_norm_gfx906(
+    torch::Tensor input, torch::Tensor residual, torch::Tensor weight,
+    double epsilon);
+
 void fused_qk_norm_rope(torch::Tensor& qkv, int64_t num_heads_q,
                         int64_t num_heads_k, int64_t num_heads_v,
                         int64_t head_dim, double eps, torch::Tensor& q_weight,
@@ -196,6 +207,10 @@ torch::Tensor ggml_dequantize(torch::Tensor W, int64_t type, int64_t m,
 torch::Tensor ggml_mul_mat_vec_a8(torch::Tensor W, torch::Tensor X,
                                   int64_t type, int64_t row);
 
+torch::Tensor ggml_mul_mat_vec_a8_sharded(std::vector<torch::Tensor> W,
+                                          torch::Tensor X,
+                                          std::vector<int64_t> types);
+
 torch::Tensor ggml_mul_mat_a8(torch::Tensor W, torch::Tensor X, int64_t type,
                               int64_t row);
 
@@ -210,6 +225,37 @@ torch::Tensor ggml_moe_a8_vec(torch::Tensor X, torch::Tensor W,
                               int64_t type, int64_t row, int64_t tokens);
 
 int64_t ggml_moe_get_block_size(int64_t type);
+
+torch::Tensor causal_conv1d_gfx906_decode_update(
+    torch::Tensor x, torch::Tensor conv_state, torch::Tensor weight,
+    std::optional<torch::Tensor> bias,
+    std::optional<torch::Tensor> conv_state_indices, int64_t pad_slot_id,
+    bool silu_activation);
+
+torch::Tensor fused_sigmoid_gating_delta_rule_gfx906_decode(
+    torch::Tensor A_log, torch::Tensor a, torch::Tensor b, torch::Tensor dt_bias,
+    torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor state,
+    double beta, double threshold, double scale,
+    bool use_qk_l2norm_in_kernel);
+
+torch::Tensor fused_sigmoid_gating_delta_rule_gfx906_indexed_decode(
+    torch::Tensor A_log, torch::Tensor a, torch::Tensor b, torch::Tensor dt_bias,
+    torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor state,
+    torch::Tensor state_indices, double beta, double threshold, double scale,
+    bool use_qk_l2norm_in_kernel);
+
+torch::Tensor fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state(
+    torch::Tensor A_log, torch::Tensor a, torch::Tensor b, torch::Tensor dt_bias,
+    torch::Tensor q, torch::Tensor k, torch::Tensor v, torch::Tensor state,
+    torch::Tensor state_indices, double beta, double threshold, double scale,
+    bool use_qk_l2norm_in_kernel);
+
+torch::Tensor fused_recurrent_gated_delta_rule_gfx906_packed_decode(
+    torch::Tensor mixed_qkv, torch::Tensor a, torch::Tensor b,
+    torch::Tensor A_log, torch::Tensor dt_bias, torch::Tensor state,
+    torch::Tensor out, torch::Tensor state_indices, double scale,
+    bool use_qk_l2norm_in_kernel, bool use_tiled_qk_head_mapping,
+    bool use_transposed_state);
 
 #ifndef USE_ROCM
 

--- a/csrc/quantization/gguf/ggml-common.h
+++ b/csrc/quantization/gguf/ggml-common.h
@@ -181,7 +181,7 @@ typedef struct {
     uint8_t qs[QK4_NL/2];
 } block_iq4_nl;
 
-#define QR4_XS 8
+#define QR4_XS 2
 #define QI4_XS (QK_K / (4*QR4_XS))
 typedef struct {
     half d;

--- a/csrc/quantization/gguf/gguf_kernel.cu
+++ b/csrc/quantization/gguf/gguf_kernel.cu
@@ -204,6 +204,140 @@ torch::Tensor ggml_mul_mat_vec_a8(torch::Tensor W,  // quant weight
   return Y;
 }
 
+torch::Tensor ggml_quantize_row_q8_1(torch::Tensor X) {
+  int col = X.sizes()[1];
+  int vecs = X.sizes()[0];
+  const int padded = (col + 512 - 1) / 512 * 512;
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(X));
+  auto options = torch::TensorOptions().dtype(torch::kInt32).device(X.device());
+  at::Tensor quant_X = torch::empty({vecs, padded / 32 * 9}, options);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+  VLLM_DISPATCH_FLOATING_TYPES(X.scalar_type(), "ggml_quantize_row_q8_1", [&] {
+    quantize_row_q8_1_cuda<scalar_t>(
+        (scalar_t*)X.data_ptr(), (void*)quant_X.data_ptr(), col, vecs, stream);
+  });
+  return quant_X;
+}
+
+template <typename scalar_t>
+static void ggml_mul_mat_vec_q8_dispatch(
+    const void* W, const void* quant_X, scalar_t* dst, int col, int row,
+    int vecs, int64_t type, cudaStream_t stream, int dst_stride) {
+  switch (type) {
+    case 2:
+      mul_mat_vec_q4_0_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 3:
+      mul_mat_vec_q4_1_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 6:
+      mul_mat_vec_q5_0_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 7:
+      mul_mat_vec_q5_1_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 8:
+      mul_mat_vec_q8_0_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 10:
+      mul_mat_vec_q2_K_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 11:
+      mul_mat_vec_q3_K_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 12:
+      mul_mat_vec_q4_K_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 13:
+      mul_mat_vec_q5_K_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 14:
+      mul_mat_vec_q6_K_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 16:
+      mul_mat_vec_iq2_xxs_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 17:
+      mul_mat_vec_iq2_xs_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 18:
+      mul_mat_vec_iq3_xxs_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 19:
+      mul_mat_vec_iq1_s_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 20:
+      mul_mat_vec_iq4_nl_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 21:
+      mul_mat_vec_iq3_s_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 22:
+      mul_mat_vec_iq2_s_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 23:
+      mul_mat_vec_iq4_xs_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+    case 29:
+      mul_mat_vec_iq1_m_q8_1_cuda<scalar_t>(
+          W, quant_X, dst, col, row, vecs, stream, dst_stride);
+      break;
+  }
+}
+
+torch::Tensor ggml_mul_mat_vec_a8_sharded(std::vector<torch::Tensor> W,
+                                          torch::Tensor X,
+                                          std::vector<int64_t> types) {
+  TORCH_CHECK(!W.empty(), "W must have at least one shard");
+  TORCH_CHECK(W.size() == types.size(),
+              "W and types must have the same number of elements");
+  int col = X.sizes()[1];
+  int vecs = X.sizes()[0];
+  int64_t total_rows = 0;
+  for (const auto& shard : W) {
+    total_rows += shard.sizes()[0];
+  }
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(X));
+  auto options = torch::TensorOptions().dtype(X.dtype()).device(X.device());
+  at::Tensor Y = torch::empty({vecs, total_rows}, options);
+  at::Tensor quant_X = ggml_quantize_row_q8_1(X);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+  VLLM_DISPATCH_FLOATING_TYPES(X.scalar_type(), "ggml_mul_mat_vec_a8_sharded",
+                               [&] {
+    int64_t row_offset = 0;
+    for (size_t i = 0; i < W.size(); ++i) {
+      const auto& shard = W[i];
+      const int row = shard.sizes()[0];
+      scalar_t* dst = (scalar_t*)Y.data_ptr() + row_offset;
+      ggml_mul_mat_vec_q8_dispatch<scalar_t>(
+          (void*)shard.data_ptr(), (void*)quant_X.data_ptr(), dst, col, row,
+          vecs, types[i], stream, total_rows);
+      row_offset += row;
+    }
+  });
+  return Y;
+}
+
 torch::Tensor ggml_mul_mat_a8(torch::Tensor W,  // quant weight
                               torch::Tensor X,  // input
                               int64_t type, int64_t row) {

--- a/csrc/quantization/gguf/mmvq.cuh
+++ b/csrc/quantization/gguf/mmvq.cuh
@@ -1,8 +1,12 @@
+#if defined(USE_ROCM)
+#define BLOCK_SIZE 64
+#else
 #define BLOCK_SIZE 128
+#endif
 
 // copied and adapted from https://github.com/ggerganov/llama.cpp/blob/b2899/ggml-cuda/mmvq.cu
 template <typename scalar_t, int qk, int qi, typename block_q_t, int vdr, vec_dot_q_cuda_t vec_dot_q_cuda>
-static __global__ void mul_mat_vec_q(const void * __restrict__ vx, const void * __restrict__ vy, scalar_t * __restrict__ dst, const int ncols, const int nrows, const int nvecs) {
+static __global__ void mul_mat_vec_q(const void * __restrict__ vx, const void * __restrict__ vy, scalar_t * __restrict__ dst, const int ncols, const int nrows, const int nvecs, const int dst_stride) {
     const auto row = blockIdx.x*blockDim.y + threadIdx.y;
     const auto vec = blockIdx.y;
 
@@ -30,192 +34,211 @@ static __global__ void mul_mat_vec_q(const void * __restrict__ vx, const void * 
         tmp += vec_dot_q_cuda(&x[ibx], &y[iby], iqs);
     }
 
-    __shared__ float shared_sum[1];
-
+    constexpr int warp_size = WARP_SIZE;
+    constexpr int num_warps = BLOCK_SIZE / warp_size;
     // sum up partial sums and write back result
 #pragma unroll
-    for (int mask = WARP_SIZE/2; mask > 0; mask >>= 1) {
+    for (int mask = warp_size/2; mask > 0; mask >>= 1) {
         tmp += VLLM_SHFL_XOR_SYNC(tmp, mask);
     }
 
-    if (threadIdx.x == 64) {
-        shared_sum[0] = tmp;
-    }
+    if constexpr (num_warps == 1) {
+        if (threadIdx.x == 0) {
+            dst[vec*dst_stride + row] = tmp;
+        }
+    } else {
+        const int lane = threadIdx.x % warp_size;
+        const int warp = threadIdx.x / warp_size;
+        __shared__ float shared_sum[num_warps];
 
-    __syncthreads();
+        if (lane == 0) {
+            shared_sum[warp] = tmp;
+        }
+        __syncthreads();
 
-    if (threadIdx.x == 0) {
-        dst[vec*nrows + row] = tmp + shared_sum[0];
+        if (warp != 0) {
+            return;
+        }
+
+        tmp = lane < num_warps ? shared_sum[lane] : 0.0f;
+#pragma unroll
+        for (int mask = warp_size/2; mask > 0; mask >>= 1) {
+            tmp += VLLM_SHFL_XOR_SYNC(tmp, mask);
+        }
+
+        if (lane == 0) {
+            dst[vec*dst_stride + row] = tmp;
+        }
     }
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_q4_0_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_q4_0_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK4_0, QI4_0, block_q4_0, VDR_Q4_0_Q8_1_MMVQ, vec_dot_q4_0_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_q4_1_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_q4_1_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK4_0, QI4_1, block_q4_1, VDR_Q4_1_Q8_1_MMVQ, vec_dot_q4_1_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_q5_0_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_q5_0_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK5_0, QI5_0, block_q5_0, VDR_Q5_0_Q8_1_MMVQ, vec_dot_q5_0_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_q5_1_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_q5_1_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK5_1, QI5_1, block_q5_1, VDR_Q5_1_Q8_1_MMVQ, vec_dot_q5_1_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_q8_0_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_q8_0_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK8_0, QI8_0, block_q8_0, VDR_Q8_0_Q8_1_MMVQ, vec_dot_q8_0_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_q2_K_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_q2_K_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI2_K, block_q2_K, VDR_Q2_K_Q8_1_MMVQ, vec_dot_q2_K_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_q3_K_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_q3_K_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI3_K, block_q3_K, VDR_Q3_K_Q8_1_MMVQ, vec_dot_q3_K_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_q4_K_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_q4_K_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI4_K, block_q4_K, VDR_Q4_K_Q8_1_MMVQ, vec_dot_q4_K_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_q5_K_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_q5_K_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI5_K, block_q5_K, VDR_Q5_K_Q8_1_MMVQ, vec_dot_q5_K_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_q6_K_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_q6_K_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI6_K, block_q6_K, VDR_Q6_K_Q8_1_MMVQ, vec_dot_q6_K_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_iq2_xxs_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_iq2_xxs_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI2_XXS, block_iq2_xxs, 1, vec_dot_iq2_xxs_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_iq2_xs_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_iq2_xs_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI2_XS, block_iq2_xs, 1, vec_dot_iq2_xs_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_iq2_s_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_iq2_s_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI2_S, block_iq2_s, 1, vec_dot_iq2_s_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_iq3_xxs_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_iq3_xxs_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI3_XXS, block_iq3_xxs, 1, vec_dot_iq3_xxs_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_iq1_s_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_iq1_s_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI1_S, block_iq1_s, 1, vec_dot_iq1_s_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_iq1_m_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_iq1_m_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI1_M, block_iq1_m, 1, vec_dot_iq1_m_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_iq4_nl_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_iq4_nl_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK4_NL, QI4_NL, block_iq4_nl, VDR_Q4_0_Q8_1_MMVQ, vec_dot_iq4_nl_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_iq4_xs_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_iq4_xs_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
-    mul_mat_vec_q<scalar_t, QK_K, QI4_XS, block_iq4_xs, 1, vec_dot_iq4_xs_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+    mul_mat_vec_q<scalar_t, QK_K, QI4_XS, block_iq4_xs, VDR_IQ4_XS_Q8_1_MMVQ, vec_dot_iq4_xs_q8_1>
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }
 
 template<typename scalar_t>
-static void mul_mat_vec_iq3_s_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+static void mul_mat_vec_iq3_s_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream, const int dst_stride = -1) {
     const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
     const dim3 block_nums(block_num_y, nvecs, 1);
     const dim3 block_dims(BLOCK_SIZE, GGML_CUDA_MMV_Y, 1);
     mul_mat_vec_q<scalar_t, QK_K, QI3_XS, block_iq3_s, 1, vec_dot_iq3_s_q8_1>
-        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs, dst_stride < 0 ? nrows : dst_stride);
 }

--- a/csrc/quantization/gguf/moe_vec.cuh
+++ b/csrc/quantization/gguf/moe_vec.cuh
@@ -317,7 +317,8 @@ static void moe_vec_iq4_xs_q8_1_cuda(const void* vx, const void* vy,
   const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
   const dim3 block_nums(block_num_y, 1, tokens * top_k);
   const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
-  moe_vec_q<scalar_t, QK_K, QI4_XS, block_iq4_xs, 1, vec_dot_iq4_xs_q8_1>
+  moe_vec_q<scalar_t, QK_K, QI4_XS, block_iq4_xs, VDR_IQ4_XS_Q8_1_MMVQ,
+            vec_dot_iq4_xs_q8_1>
       <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, topk_ids, top_k,
                                               ncols, nrows, token_stride);
 }

--- a/csrc/quantization/gguf/vecdotq.cuh
+++ b/csrc/quantization/gguf/vecdotq.cuh
@@ -1788,25 +1788,30 @@ static __device__ __forceinline__ float vec_dot_iq4_nl_q8_1(
 }
 
 
+#define VDR_IQ4_XS_Q8_1_MMVQ 4
+
 static __device__ __forceinline__ float vec_dot_iq4_xs_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & iqs) {
 #if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 610 || defined USE_ROCM
     const block_iq4_xs * bq4 = (const block_iq4_xs *) vbq;
     const uint8_t * values = (const uint8_t *)kvalues_iq4nl;
 
-    // iqs is 0...7
-    const int ib32 = iqs;
-    const int32_t  * q8 = (const int *)bq8_1[ib32].qs;
-    const uint32_t * q4 = (const uint32_t *)bq4->qs + 4*ib32;
-    const int8_t ls = ((bq4->scales_l[ib32/2] >> 4*(ib32%2)) & 0xf) | (((bq4->scales_h >> 2*ib32) & 3) << 4);
-    const float d = __half2float(bq4->d) * (ls - 32) * __low2float(bq8_1[ib32].ds);
-    int v1, v2;
-    int sumi1 = 0, sumi2 = 0;
+    int sumi = 0;
+#pragma unroll
     for (int j = 0; j < 4; ++j) {
-        get_int_from_table_16(q4[j], values, v1, v2);
-        sumi1 = __dp4a(v1, q8[j+0], sumi1);
-        sumi2 = __dp4a(v2, q8[j+4], sumi2);
+        const uint32_t aux_q4 = get_int_b4(bq4->qs, iqs + j);
+        int v1, v2;
+        get_int_from_table_16(aux_q4, values, v1, v2);
+
+        const int u0 = get_int_b4(bq8_1[iqs/4].qs, j + 0);
+        const int u1 = get_int_b4(bq8_1[iqs/4].qs, j + 4);
+
+        sumi = __dp4a(v1, u0, sumi);
+        sumi = __dp4a(v2, u1, sumi);
     }
-    return d * (sumi1 + sumi2);
+
+    const int ls = ((bq4->scales_l[iqs/8] >> (iqs & 0x04)) & 0x0F) | (((bq4->scales_h >> (iqs/2)) & 0x03) << 4);
+    const float d = __half2float(bq4->d) * (ls - 32) * __low2float(bq8_1[iqs/4].ds);
+    return d * sumi;
 #endif
 }

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -162,6 +162,22 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "float epsilon) -> ()");
   ops.impl("fused_add_rms_norm", torch::kCUDA, &fused_add_rms_norm);
 
+  ops.def(
+      "rms_norm_gated_gfx906(Tensor input, Tensor weight, Tensor gate, "
+      "float epsilon, bool norm_before_gate) -> Tensor");
+  ops.impl("rms_norm_gated_gfx906", torch::kCUDA, &rms_norm_gated_gfx906);
+
+  ops.def(
+      "gemma_rms_norm_gfx906(Tensor input, Tensor weight, float epsilon) -> "
+      "Tensor");
+  ops.impl("gemma_rms_norm_gfx906", torch::kCUDA, &gemma_rms_norm_gfx906);
+
+  ops.def(
+      "gemma_fused_add_rms_norm_gfx906(Tensor input, Tensor residual, Tensor "
+      "weight, float epsilon) -> Tensor[]");
+  ops.impl("gemma_fused_add_rms_norm_gfx906", torch::kCUDA,
+           &gemma_fused_add_rms_norm_gfx906);
+
   // Function for fused QK Norm and RoPE
   ops.def(
       "fused_qk_norm_rope(Tensor! qkv, int num_heads_q, "
@@ -356,6 +372,12 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "-> Tensor");
   ops.impl("ggml_mul_mat_vec_a8", torch::kCUDA, &ggml_mul_mat_vec_a8);
 
+  ops.def(
+      "ggml_mul_mat_vec_a8_sharded(Tensor[] W, Tensor X, int[] types) "
+      "-> Tensor");
+  ops.impl("ggml_mul_mat_vec_a8_sharded", torch::kCUDA,
+           &ggml_mul_mat_vec_a8_sharded);
+
   // mmq kernel for GGML.
   ops.def(
       "ggml_mul_mat_a8(Tensor W, Tensor X, int type, SymInt row) -> Tensor");
@@ -376,6 +398,48 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("ggml_moe_a8_vec", torch::kCUDA, &ggml_moe_a8_vec);
 
   ops.def("ggml_moe_get_block_size", &ggml_moe_get_block_size);
+
+  ops.def(
+      "causal_conv1d_gfx906_decode_update("
+      "Tensor x, Tensor conv_state, Tensor weight, Tensor? bias, "
+      "Tensor? conv_state_indices, int pad_slot_id, bool silu_activation) "
+      "-> Tensor");
+  ops.impl("causal_conv1d_gfx906_decode_update", torch::kCUDA,
+           &causal_conv1d_gfx906_decode_update);
+
+  ops.def(
+      "fused_sigmoid_gating_delta_rule_gfx906_decode("
+      "Tensor A_log, Tensor a, Tensor b, Tensor dt_bias, Tensor q, Tensor k, "
+      "Tensor v, Tensor state, float beta, float threshold, float scale, "
+      "bool use_qk_l2norm_in_kernel) -> Tensor");
+  ops.impl("fused_sigmoid_gating_delta_rule_gfx906_decode", torch::kCUDA,
+           &fused_sigmoid_gating_delta_rule_gfx906_decode);
+
+  ops.def(
+      "fused_sigmoid_gating_delta_rule_gfx906_indexed_decode("
+      "Tensor A_log, Tensor a, Tensor b, Tensor dt_bias, Tensor q, Tensor k, "
+      "Tensor v, Tensor state, Tensor state_indices, float beta, "
+      "float threshold, float scale, bool use_qk_l2norm_in_kernel) -> Tensor");
+  ops.impl("fused_sigmoid_gating_delta_rule_gfx906_indexed_decode", torch::kCUDA,
+           &fused_sigmoid_gating_delta_rule_gfx906_indexed_decode);
+
+  ops.def(
+      "fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state("
+      "Tensor A_log, Tensor a, Tensor b, Tensor dt_bias, Tensor q, Tensor k, "
+      "Tensor v, Tensor state, Tensor state_indices, float beta, "
+      "float threshold, float scale, bool use_qk_l2norm_in_kernel) -> Tensor");
+  ops.impl("fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state",
+           torch::kCUDA,
+           &fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state);
+
+  ops.def(
+      "fused_recurrent_gated_delta_rule_gfx906_packed_decode("
+      "Tensor mixed_qkv, Tensor a, Tensor b, Tensor A_log, Tensor dt_bias, "
+      "Tensor state, Tensor out, Tensor state_indices, float scale, "
+      "bool use_qk_l2norm_in_kernel, bool use_tiled_qk_head_mapping, "
+      "bool use_transposed_state) -> Tensor");
+  ops.impl("fused_recurrent_gated_delta_rule_gfx906_packed_decode", torch::kCUDA,
+           &fused_recurrent_gated_delta_rule_gfx906_packed_decode);
 
 #ifndef USE_ROCM
   // CUTLASS nvfp4 block scaled GEMM

--- a/tests/kernels/core/test_layernorm.py
+++ b/tests/kernels/core/test_layernorm.py
@@ -6,7 +6,7 @@ import torch
 
 from tests.kernels.quant_utils import FP8_DTYPE
 from tests.kernels.utils import opcheck
-from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm
 from vllm.platforms import current_platform
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
@@ -68,6 +68,73 @@ def test_rms_norm(
         opcheck(
             torch.ops._C.rms_norm, (out, x, layer.weight.data, layer.variance_epsilon)
         )
+
+
+@pytest.mark.parametrize("norm_before_gate", [False, True])
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+@torch.inference_mode()
+def test_rms_norm_gated_gfx906(dtype: torch.dtype, norm_before_gate: bool) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    device = "cuda"
+    torch.manual_seed(0)
+    num_tokens = 5
+    hidden_size = 1024
+    eps = 1e-6
+    x = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype) * 0.1
+    z = torch.randn_like(x) * 0.1
+    weight = (torch.randn(hidden_size, device=device, dtype=dtype) * 0.1 + 1.0)
+
+    actual = torch.ops._C.rms_norm_gated_gfx906(
+        x, weight, z, eps, norm_before_gate
+    )
+    ref_x = x.float()
+    if not norm_before_gate:
+        ref_x = ref_x * torch.nn.functional.silu(z.float())
+    ref = ref_x * torch.rsqrt(ref_x.pow(2).mean(dim=-1, keepdim=True) + eps)
+    ref = ref * weight.float()
+    if norm_before_gate:
+        ref = ref * torch.nn.functional.silu(z.float())
+    ref = ref.to(dtype)
+
+    torch.testing.assert_close(actual, ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("shape", [(3, 2560), (1, 16, 128)])
+@pytest.mark.parametrize("add_residual", [False, True])
+@pytest.mark.parametrize("dtype", [torch.half, torch.float])
+@torch.inference_mode()
+def test_gemma_rms_norm_gfx906(
+    shape: tuple[int, ...],
+    add_residual: bool,
+    dtype: torch.dtype,
+) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    if not hasattr(torch.ops._C, "gemma_rms_norm_gfx906"):
+        pytest.skip("gemma_rms_norm_gfx906 is not available")
+
+    device = "cuda"
+    torch.manual_seed(0)
+    hidden_size = shape[-1]
+    layer = GemmaRMSNorm(hidden_size).to(device=device, dtype=dtype)
+    layer.weight.data.normal_(mean=0.0, std=0.1)
+    x = torch.randn(*shape, device=device, dtype=dtype) * 0.1
+    residual = torch.randn_like(x) * 0.1 if add_residual else None
+
+    ref = layer.forward_native(x, residual)
+    if residual is None:
+        actual = torch.ops._C.gemma_rms_norm_gfx906(
+            x, layer.weight.data, layer.variance_epsilon
+        )
+        torch.testing.assert_close(actual, ref, atol=1e-2, rtol=1e-2)
+    else:
+        actual = torch.ops._C.gemma_fused_add_rms_norm_gfx906(
+            x, residual, layer.weight.data, layer.variance_epsilon
+        )
+        torch.testing.assert_close(actual[0], ref[0], atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(actual[1], ref[1], atol=1e-5, rtol=1e-5)
 
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)

--- a/tests/kernels/mamba/test_causal_conv1d.py
+++ b/tests/kernels/mamba/test_causal_conv1d.py
@@ -183,6 +183,32 @@ def test_causal_conv1d_update(dim, width, seqlen, has_bias, silu_activation, ity
     assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
 
 
+def test_causal_conv1d_update_accepts_float32_state_with_fp16_input():
+    device = "cuda"
+    current_platform.seed_everything(0)
+    batch, dim, width = 2, 128, 4
+    x = torch.randn(batch, dim, 1, device=device, dtype=torch.float16)
+    weight = torch.randn(dim, width, device=device, dtype=torch.float16)
+    conv_state = torch.randn(batch, dim, width - 1, device=device, dtype=torch.float32)
+    conv_state_ref = conv_state.clone()
+    conv_state_indices = torch.arange(batch, dtype=torch.int32, device=device)
+
+    out = causal_conv1d_update(
+        x,
+        conv_state,
+        weight,
+        bias=None,
+        activation="silu",
+        conv_state_indices=conv_state_indices,
+    )
+    out_ref = causal_conv1d_update_ref(
+        x, conv_state_ref, weight, bias=None, activation="silu"
+    )
+
+    torch.testing.assert_close(out, out_ref, rtol=3e-3, atol=5e-3)
+    torch.testing.assert_close(conv_state, conv_state_ref, rtol=1e-3, atol=1e-3)
+
+
 @pytest.mark.parametrize("itype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("silu_activation", [False, True])
 @pytest.mark.parametrize("has_bias", [False, True])

--- a/tests/kernels/mamba/test_fused_recurrent_packed_decode.py
+++ b/tests/kernels/mamba/test_fused_recurrent_packed_decode.py
@@ -59,6 +59,66 @@ def _packed_decode_ref(
     return output, final_state
 
 
+def _packed_decode_transposed_state_ref(
+    mixed_qkv,
+    a,
+    b,
+    A_log,
+    dt_bias,
+    scale,
+    initial_state,
+    ssm_state_indices,
+    use_qk_l2norm_in_kernel,
+    use_tiled_qk_head_mapping,
+):
+    batch = mixed_qkv.shape[0]
+    hv, value_dim, key_dim = initial_state.shape[-3:]
+    assert value_dim == key_dim
+    qkv_dim = mixed_qkv.shape[1]
+    qk_dim = qkv_dim - hv * value_dim
+    heads = qk_dim // (2 * key_dim)
+    head_ratio = hv // heads
+    output = torch.zeros(
+        batch, 1, hv, value_dim, device=mixed_qkv.device, dtype=mixed_qkv.dtype
+    )
+    final_state = initial_state.clone()
+
+    for batch_idx in range(batch):
+        state_idx = int(ssm_state_indices[batch_idx].item())
+        if state_idx < 0:
+            continue
+        state = final_state[state_idx].float().clone()
+        for head_idx in range(hv):
+            q_head_idx = (
+                head_idx % heads
+                if use_tiled_qk_head_mapping
+                else head_idx // head_ratio
+            )
+            q_offset = q_head_idx * key_dim
+            k_offset = heads * key_dim + q_head_idx * key_dim
+            v_offset = 2 * heads * key_dim + head_idx * value_dim
+            q_t = mixed_qkv[batch_idx, q_offset : q_offset + key_dim].float()
+            k_t = mixed_qkv[batch_idx, k_offset : k_offset + key_dim].float()
+            v_t = mixed_qkv[batch_idx, v_offset : v_offset + value_dim].float()
+            if use_qk_l2norm_in_kernel:
+                q_t = q_t * torch.rsqrt(torch.sum(q_t * q_t) + 1e-6)
+                k_t = k_t * torch.rsqrt(torch.sum(k_t * k_t) + 1e-6)
+            q_t = q_t * scale
+            x = a[batch_idx, head_idx].float() + dt_bias[head_idx].float()
+            softplus_x = torch.where(x <= 20.0, torch.log1p(torch.exp(x)), x)
+            g_val = -torch.exp(A_log[head_idx].float()) * softplus_x
+            beta_val = torch.sigmoid(b[batch_idx, head_idx].float())
+            state_head = state[head_idx] * torch.exp(g_val)
+            v_residual = v_t - torch.sum(state_head * k_t[:, None], dim=0)
+            state_head = state_head + k_t[:, None] * (v_residual * beta_val)[None, :]
+            output[batch_idx, 0, head_idx] = torch.sum(
+                state_head * q_t[:, None], dim=0
+            ).to(output.dtype)
+            state[head_idx] = state_head
+        final_state[state_idx] = state.to(final_state.dtype)
+    return output, final_state
+
+
 def test_gfx906_packed_decode_matches_reference():
     torch.manual_seed(0)
     device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -101,6 +161,110 @@ def test_gfx906_packed_decode_matches_reference():
         initial_state=initial_state,
         ssm_state_indices=indices,
         use_qk_l2norm_in_kernel=True,
+    )
+
+    torch.testing.assert_close(actual_out, expected_out, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(actual_state, expected_state, rtol=1e-3, atol=1e-3)
+
+
+def test_gfx906_packed_decode_matches_transposed_qwen_cache_reference():
+    torch.manual_seed(1)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.float16
+    batch, heads, hv, key_dim, value_dim = 4, 2, 4, 8, 8
+    mixed_qkv = torch.randn(
+        batch,
+        2 * heads * key_dim + hv * value_dim,
+        device=device,
+        dtype=dtype,
+    )
+    a = torch.randn(batch, hv, device=device, dtype=dtype)
+    b = torch.randn(batch, hv, device=device, dtype=dtype)
+    A_log = torch.randn(hv, device=device, dtype=dtype)
+    dt_bias = torch.randn(hv, device=device, dtype=dtype)
+    initial_state = torch.randn(6, hv, value_dim, key_dim, device=device, dtype=torch.float32)
+    indices = torch.tensor([2, -1, 4, 1], device=device, dtype=torch.int32)
+    scale = key_dim**-0.5
+
+    out = torch.empty(batch, 1, hv, value_dim, device=device, dtype=dtype)
+    actual_out, actual_state = fused_recurrent_gated_delta_rule_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=initial_state.clone(),
+        out=out,
+        ssm_state_indices=indices,
+        use_qk_l2norm_in_kernel=True,
+        use_tiled_qk_head_mapping=True,
+        use_transposed_state=True,
+    )
+    expected_out, expected_state = _packed_decode_transposed_state_ref(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=initial_state,
+        ssm_state_indices=indices,
+        use_qk_l2norm_in_kernel=True,
+        use_tiled_qk_head_mapping=True,
+    )
+
+    torch.testing.assert_close(actual_out, expected_out, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(actual_state, expected_state, rtol=1e-3, atol=1e-3)
+
+
+def test_gfx906_packed_decode_matches_qwen35_shared_qk_reference():
+    torch.manual_seed(2)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.float16
+    batch, heads, hv, key_dim, value_dim = 3, 16, 32, 128, 128
+    mixed_qkv = torch.randn(
+        batch,
+        2 * heads * key_dim + hv * value_dim,
+        device=device,
+        dtype=dtype,
+    )
+    a = torch.randn(batch, hv, device=device, dtype=dtype)
+    b = torch.randn(batch, hv, device=device, dtype=dtype)
+    A_log = torch.randn(hv, device=device, dtype=dtype)
+    dt_bias = torch.randn(hv, device=device, dtype=dtype)
+    initial_state = torch.randn(
+        6, hv, value_dim, key_dim, device=device, dtype=torch.float32
+    )
+    indices = torch.tensor([2, -1, 4], device=device, dtype=torch.int32)
+    scale = key_dim**-0.5
+
+    out = torch.empty(batch, 1, hv, value_dim, device=device, dtype=dtype)
+    actual_out, actual_state = fused_recurrent_gated_delta_rule_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=initial_state.clone(),
+        out=out,
+        ssm_state_indices=indices,
+        use_qk_l2norm_in_kernel=True,
+        use_tiled_qk_head_mapping=True,
+        use_transposed_state=True,
+    )
+    expected_out, expected_state = _packed_decode_transposed_state_ref(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=initial_state,
+        ssm_state_indices=indices,
+        use_qk_l2norm_in_kernel=True,
+        use_tiled_qk_head_mapping=True,
     )
 
     torch.testing.assert_close(actual_out, expected_out, rtol=1e-3, atol=1e-3)

--- a/tests/kernels/mamba/test_fused_sigmoid_gating.py
+++ b/tests/kernels/mamba/test_fused_sigmoid_gating.py
@@ -1,5 +1,6 @@
 import torch
 
+from vllm import _custom_ops as ops
 from vllm.model_executor.layers.fla.ops import fused_sigmoid_gating as fsg
 
 
@@ -59,3 +60,289 @@ def test_gfx906_decode_sigmoid_gating_matches_eager_fallback():
 
     torch.testing.assert_close(decode_out, eager_out, rtol=1e-3, atol=1e-3)
     torch.testing.assert_close(decode_final, eager_final, rtol=1e-3, atol=1e-3)
+
+
+def test_gfx906_decode_sigmoid_gating_accepts_float32_state():
+    torch.manual_seed(0)
+    dtype = torch.float16
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    tokens, heads, kv_heads, key_dim, value_dim = 3, 2, 4, 8, 3
+    q = torch.randn(1, tokens, heads, key_dim, device=device, dtype=dtype)
+    k = torch.randn(1, tokens, heads, key_dim, device=device, dtype=dtype)
+    v = torch.randn(1, tokens, kv_heads, value_dim, device=device, dtype=dtype)
+    a = torch.randn(tokens, kv_heads, device=device, dtype=dtype)
+    b = torch.randn(tokens, kv_heads, device=device, dtype=dtype)
+    A_log = torch.randn(kv_heads, device=device, dtype=dtype)
+    dt_bias = torch.randn(kv_heads, device=device, dtype=dtype)
+    initial_state = torch.randn(
+        tokens,
+        kv_heads,
+        value_dim,
+        key_dim,
+        device=device,
+        dtype=torch.float32,
+    )
+
+    eager_state = initial_state.clone()
+    decode_state = initial_state.clone()
+    cu_seqlens = torch.arange(tokens + 1, device=device, dtype=torch.int32)
+    scale = key_dim**-0.5
+
+    eager_out, eager_final = fsg._fused_sigmoid_gating_delta_rule_update_gfx906_eager(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        beta=1.0,
+        threshold=20.0,
+        scale=scale,
+        initial_state=eager_state,
+        inplace_final_state=True,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=None,
+        num_accepted_tokens=None,
+        use_qk_l2norm_in_kernel=True,
+    )
+    decode_out, decode_final = fsg._fused_sigmoid_gating_delta_rule_decode_gfx906(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        beta=1.0,
+        threshold=20.0,
+        scale=scale,
+        initial_state=decode_state,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    torch.testing.assert_close(decode_out, eager_out, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(decode_final, eager_final, rtol=1e-3, atol=1e-3)
+
+
+def test_gfx906_indexed_decode_sigmoid_gating_updates_source_state():
+    torch.manual_seed(0)
+    dtype = torch.float16
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    tokens, slots, heads, kv_heads, key_dim, value_dim = 3, 7, 2, 4, 8, 3
+    q = torch.randn(1, tokens, heads, key_dim, device=device, dtype=dtype)
+    k = torch.randn(1, tokens, heads, key_dim, device=device, dtype=dtype)
+    v = torch.randn(1, tokens, kv_heads, value_dim, device=device, dtype=dtype)
+    a = torch.randn(tokens, kv_heads, device=device, dtype=dtype)
+    b = torch.randn(tokens, kv_heads, device=device, dtype=dtype)
+    A_log = torch.randn(kv_heads, device=device, dtype=dtype)
+    dt_bias = torch.randn(kv_heads, device=device, dtype=dtype)
+    state_indices = torch.tensor([3, 1, 5], device=device, dtype=torch.int32)
+    source_state = torch.randn(
+        slots,
+        kv_heads,
+        value_dim,
+        key_dim,
+        device=device,
+        dtype=torch.float32,
+    )
+
+    gathered_state = source_state[state_indices].clone()
+    direct_state = source_state.clone()
+    cu_seqlens = torch.arange(tokens + 1, device=device, dtype=torch.int32)
+    scale = key_dim**-0.5
+
+    eager_out, eager_final = fsg._fused_sigmoid_gating_delta_rule_update_gfx906_eager(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        beta=1.0,
+        threshold=20.0,
+        scale=scale,
+        initial_state=gathered_state,
+        inplace_final_state=True,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=None,
+        num_accepted_tokens=None,
+        use_qk_l2norm_in_kernel=True,
+    )
+    direct_out, direct_final = (
+        fsg._fused_sigmoid_gating_delta_rule_indexed_decode_gfx906(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dt_bias,
+            q=q,
+            k=k,
+            v=v,
+            beta=1.0,
+            threshold=20.0,
+            scale=scale,
+            initial_state=direct_state,
+            ssm_state_indices=state_indices,
+            use_qk_l2norm_in_kernel=True,
+        )
+    )
+
+    torch.testing.assert_close(direct_out, eager_out, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(
+        direct_final[state_indices], eager_final, rtol=1e-3, atol=1e-3
+    )
+    untouched = torch.ones(slots, device=device, dtype=torch.bool)
+    untouched[state_indices.long()] = False
+    torch.testing.assert_close(direct_final[untouched], source_state[untouched])
+
+
+def test_gfx906_indexed_decode_sigmoid_gating_updates_kv_cache_state():
+    torch.manual_seed(0)
+    dtype = torch.float16
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    tokens, slots, heads, kv_heads, key_dim, value_dim = 3, 7, 2, 4, 8, 3
+    q = torch.randn(1, tokens, heads, key_dim, device=device, dtype=dtype)
+    k = torch.randn(1, tokens, heads, key_dim, device=device, dtype=dtype)
+    v = torch.randn(1, tokens, kv_heads, value_dim, device=device, dtype=dtype)
+    a = torch.randn(tokens, kv_heads, device=device, dtype=dtype)
+    b = torch.randn(tokens, kv_heads, device=device, dtype=dtype)
+    A_log = torch.randn(kv_heads, device=device, dtype=dtype)
+    dt_bias = torch.randn(kv_heads, device=device, dtype=dtype)
+    state_indices = torch.tensor([3, 1, 5], device=device, dtype=torch.int32)
+    cache_state = torch.randn(
+        slots,
+        kv_heads,
+        key_dim,
+        value_dim,
+        device=device,
+        dtype=torch.float32,
+    )
+
+    gathered_state = cache_state[state_indices].transpose(-1, -2).contiguous()
+    direct_state = cache_state.clone()
+    cu_seqlens = torch.arange(tokens + 1, device=device, dtype=torch.int32)
+    scale = key_dim**-0.5
+
+    eager_out, eager_final = fsg._fused_sigmoid_gating_delta_rule_update_gfx906_eager(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        beta=1.0,
+        threshold=20.0,
+        scale=scale,
+        initial_state=gathered_state,
+        inplace_final_state=True,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=None,
+        num_accepted_tokens=None,
+        use_qk_l2norm_in_kernel=True,
+    )
+    direct_out, direct_final = (
+        fsg.fused_sigmoid_gating_delta_rule_update_kv_cache_gfx906(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dt_bias,
+            q=q,
+            k=k,
+            v=v,
+            beta=1.0,
+            threshold=20.0,
+            scale=scale,
+            initial_state=direct_state,
+            ssm_state_indices=state_indices,
+            use_qk_l2norm_in_kernel=True,
+        )
+    )
+
+    torch.testing.assert_close(direct_out, eager_out, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(
+        direct_final[state_indices].transpose(-1, -2),
+        eager_final,
+        rtol=1e-3,
+        atol=1e-3,
+    )
+    untouched = torch.ones(slots, device=device, dtype=torch.bool)
+    untouched[state_indices.long()] = False
+    torch.testing.assert_close(direct_final[untouched], cache_state[untouched])
+
+
+def test_gfx906_packed_decode_matches_indexed_decode():
+    torch.manual_seed(0)
+    dtype = torch.float16
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    tokens, slots, heads, kv_heads, key_dim, value_dim = 3, 7, 2, 4, 8, 3
+    q = torch.randn(1, tokens, heads, key_dim, device=device, dtype=dtype)
+    k = torch.randn(1, tokens, heads, key_dim, device=device, dtype=dtype)
+    v = torch.randn(1, tokens, kv_heads, value_dim, device=device, dtype=dtype)
+    a = torch.randn(tokens, kv_heads, device=device, dtype=dtype)
+    b = torch.randn(tokens, kv_heads, device=device, dtype=dtype)
+    A_log = torch.randn(kv_heads, device=device, dtype=dtype)
+    dt_bias = torch.randn(kv_heads, device=device, dtype=dtype)
+    state_indices = torch.tensor([3, 1, 5], device=device, dtype=torch.int32)
+    source_state = torch.randn(
+        slots,
+        kv_heads,
+        value_dim,
+        key_dim,
+        device=device,
+        dtype=torch.float32,
+    )
+    mixed_qkv = torch.cat(
+        (
+            q.squeeze(0).reshape(tokens, -1),
+            k.squeeze(0).reshape(tokens, -1),
+            v.squeeze(0).reshape(tokens, -1),
+        ),
+        dim=-1,
+    ).contiguous()
+    scale = key_dim**-0.5
+
+    indexed_state = source_state.clone()
+    indexed_out, _ = fsg._fused_sigmoid_gating_delta_rule_indexed_decode_gfx906(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        beta=1.0,
+        threshold=20.0,
+        scale=scale,
+        initial_state=indexed_state,
+        ssm_state_indices=state_indices,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    packed_state = source_state.clone()
+    packed_out = torch.empty(
+        tokens,
+        1,
+        kv_heads,
+        value_dim,
+        device=device,
+        dtype=dtype,
+    )
+    ops.fused_recurrent_gated_delta_rule_gfx906_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        state=packed_state,
+        out=packed_out,
+        state_indices=state_indices,
+        scale=scale,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    torch.testing.assert_close(
+        packed_out.squeeze(1), indexed_out.squeeze(0), rtol=1e-3, atol=1e-3
+    )
+    torch.testing.assert_close(packed_state, indexed_state, rtol=1e-3, atol=1e-3)

--- a/tests/model_executor/test_gguf_dense_fallback.py
+++ b/tests/model_executor/test_gguf_dense_fallback.py
@@ -6,26 +6,43 @@ from vllm.model_executor.layers.quantization import gguf
 from vllm.model_executor.layers.quantization.gguf import GGUFLinearMethod
 
 
-def test_dense_gguf_fallback_matches_input_dtype_for_weight_and_bias():
+def test_gfx906_qwen35_linear_attn_gguf_uses_packed_weight(monkeypatch):
     method = GGUFLinearMethod(quant_config=SimpleNamespace())
-    layer = SimpleNamespace(
-        use_dense_gguf_fallback=True,
-        weight=torch.tensor(
-            [
-                [1.0, 2.0],
-                [3.0, 4.0],
-            ],
-            dtype=torch.float16,
-        ),
+    method.params_dtype = torch.float16
+    monkeypatch.setattr(gguf, "on_gfx906", lambda: True)
+
+    qweight = torch.nn.Parameter(
+        torch.empty(0, dtype=torch.uint8),
+        requires_grad=False,
     )
-    x = torch.tensor([[5.0, 6.0]], dtype=torch.float32)
-    bias = torch.tensor([0.5, -0.5], dtype=torch.float16)
+    qweight.shard_id = ["qkv", "z"]
+    qweight.shard_id_map = {"qkv": 0, "z": 1}
+    qweight.data_container = [
+        torch.ones((2, 3), dtype=torch.uint8),
+        torch.ones((4, 5), dtype=torch.uint8) * 2,
+    ]
 
-    out = method.apply(layer, x, bias)
+    layer = torch.nn.Module()
+    layer.prefix = "model.layers.0.linear_attn.in_proj_qkv"
+    layer.register_parameter("qweight", qweight)
+    layer.qweight_type = SimpleNamespace(weight_type=gguf.WeightType.Q4_K)
 
-    expected = x @ layer.weight.to(dtype=x.dtype).T + bias.to(dtype=x.dtype)
-    assert out.dtype == x.dtype
-    torch.testing.assert_close(out, expected)
+    method.process_weights_after_loading(layer)
+
+    assert not getattr(layer, "use_dense_gguf_fallback", False)
+    assert layer.qweight is not None
+    assert not hasattr(layer, "weight")
+    assert layer.qweight.shape == (6, 5)
+    assert layer.qweight.dtype == torch.uint8
+    assert layer.qweight.shard_offset_map == {
+        "qkv": (0, 2, 3),
+        "z": (2, 6, 5),
+    }
+    assert set(layer._gguf_contiguous_shard_cache) == {"qkv"}
+    torch.testing.assert_close(
+        layer._gguf_contiguous_shard_cache["qkv"],
+        torch.ones((2, 3), dtype=torch.uint8),
+    )
 
 
 def test_gfx906_non_linear_attn_gguf_uses_packed_weight(monkeypatch):
@@ -60,3 +77,8 @@ def test_gfx906_non_linear_attn_gguf_uses_packed_weight(monkeypatch):
         0: (0, 2, 3),
         1: (2, 6, 5),
     }
+    assert set(layer._gguf_contiguous_shard_cache) == {0}
+    torch.testing.assert_close(
+        layer._gguf_contiguous_shard_cache[0],
+        torch.ones((2, 3), dtype=torch.uint8),
+    )

--- a/tests/model_executor/test_qwen3_5_gdn.py
+++ b/tests/model_executor/test_qwen3_5_gdn.py
@@ -52,8 +52,10 @@ def test_qwen3_5_split_gdn_calls_core_with_b_then_a(monkeypatch):
     b = torch.full((3, 2), 11.0)
     a = torch.full((3, 2), 22.0)
 
-    module.in_proj_qkvz = _FakeLinear(torch.cat((mixed_qkv, z), dim=-1))
-    module.in_proj_ba = _FakeLinear(torch.cat((b, a), dim=-1))
+    module.in_proj_qkv = _FakeLinear(mixed_qkv)
+    module.in_proj_z = _FakeLinear(z)
+    module.in_proj_b = _FakeLinear(b)
+    module.in_proj_a = _FakeLinear(a)
 
     captured: dict[str, torch.Tensor] = {}
 

--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -198,7 +198,8 @@ class TestGGUFModelLoader:
 
         hf_config = MagicMock()
         hf_config.model_type = "qwen3_5_text"
-        hf_config.num_hidden_layers = 1
+        hf_config.num_hidden_layers = 2
+        hf_config.layer_types = ["linear_attention", "full_attention"]
         hf_config.vision_config = None
         hf_config.get_text_config.return_value = hf_config
 
@@ -216,6 +217,56 @@ class TestGGUFModelLoader:
         assert weights_map["blk.0.attn_qkv.weight"] == (
             "language_model.model.layers.0.linear_attn.in_proj_qkv.weight"
         )
+        assert "blk.1.attn_qkv.weight" not in weights_map
+
+    @patch("vllm.model_executor.model_loader.gguf_loader.detect_gguf_multimodal")
+    @patch("vllm.model_executor.model_loader.gguf_loader.AutoModelForCausalLM")
+    def test_qwen3_5_gguf_map_handles_split_gdn_projections(
+        self,
+        mock_auto_model,
+        mock_detect_multimodal,
+    ):
+        mock_detect_multimodal.return_value = None
+        mock_hf_model = MagicMock()
+        mock_hf_model.state_dict.return_value = {
+            "model.layers.0.linear_attn.in_proj_qkv.weight": MagicMock(),
+            "model.layers.0.linear_attn.in_proj_z.weight": MagicMock(),
+            "model.layers.0.linear_attn.in_proj_b.weight": MagicMock(),
+            "model.layers.0.linear_attn.in_proj_a.weight": MagicMock(),
+        }
+        mock_auto_model.from_config.return_value = mock_hf_model
+
+        hf_config = MagicMock()
+        hf_config.model_type = "qwen3_5_text"
+        hf_config.num_hidden_layers = 2
+        hf_config.layer_types = ["linear_attention", "full_attention"]
+        hf_config.vision_config = None
+        hf_config.get_text_config.return_value = hf_config
+
+        model_config = MagicMock()
+        model_config.hf_config = hf_config
+        model_config.architecture = "Qwen3_5ForCausalLM"
+        model_config.trust_remote_code = False
+        model_config.model = "/tmp/qwen3.6.gguf"
+
+        load_config = LoadConfig(load_format="gguf")
+        loader = GGUFModelLoader(load_config)
+
+        weights_map = loader._get_gguf_weights_map(model_config)
+
+        assert weights_map["blk.0.attn_qkv.weight"] == (
+            "language_model.model.layers.0.linear_attn.in_proj_qkv.weight"
+        )
+        assert weights_map["blk.0.attn_gate.weight"] == (
+            "language_model.model.layers.0.linear_attn.in_proj_z.weight"
+        )
+        assert weights_map["blk.0.ssm_beta.weight"] == (
+            "language_model.model.layers.0.linear_attn.in_proj_b.weight"
+        )
+        assert weights_map["blk.0.ssm_alpha.weight"] == (
+            "language_model.model.layers.0.linear_attn.in_proj_a.weight"
+        )
+        assert "blk.1.attn_qkv.weight" not in weights_map
 
     @patch("vllm.config.model.get_hf_image_processor_config", return_value=None)
     @patch("vllm.transformers_utils.config.file_or_path_exists", return_value=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,7 @@ from vllm.config.utils import get_field
 from vllm.config.vllm import (
     OPTIMIZATION_LEVEL_TO_CONFIG,
     OptimizationLevel,
+    needs_qwen35_gguf_piecewise_cudagraph,
 )
 from vllm.model_executor.models.config import Qwen3_5ForCausalLMConfig
 from vllm.model_executor.layers.pooler import PoolingType
@@ -54,6 +55,90 @@ def test_qwen3_5_gguf_uses_qwen3_5_reasoning_parser():
     Qwen3_5ForCausalLMConfig.verify_and_update_config(vllm_config)
 
     assert structured_outputs_config.reasoning_parser == "qwen3_5"
+
+
+def test_qwen3_5_gguf_on_gfx906_needs_piecewise_cudagraph(monkeypatch):
+    class MockPlatform:
+
+        @staticmethod
+        def is_rocm():
+            return True
+
+        @staticmethod
+        def get_device_capability():
+            return SimpleNamespace(major=9, minor=0)
+
+    monkeypatch.setattr("vllm.platforms.current_platform", MockPlatform)
+
+    qwen35_gguf = SimpleNamespace(
+        quantization="gguf",
+        hf_text_config=SimpleNamespace(model_type="qwen3_5_text"),
+    )
+    qwen35_dense = SimpleNamespace(
+        quantization=None,
+        hf_text_config=SimpleNamespace(model_type="qwen3_5_text"),
+    )
+    other_gguf = SimpleNamespace(
+        quantization="gguf",
+        hf_text_config=SimpleNamespace(model_type="llama"),
+    )
+
+    assert needs_qwen35_gguf_piecewise_cudagraph(qwen35_gguf)
+    assert not needs_qwen35_gguf_piecewise_cudagraph(qwen35_dense)
+    assert not needs_qwen35_gguf_piecewise_cudagraph(other_gguf)
+
+
+def test_local_gguf_companion_config_uses_tokenizer_repo(tmp_path):
+    model_path = tmp_path / "Qwen3.5-27B-Q6_K.gguf"
+    model_path.write_bytes(b"GGUF")
+    tokenizer_path = tmp_path / "Qwen3.5-27B-UD-Q6_K_XL-repo"
+    tokenizer_path.mkdir()
+    (tokenizer_path / "config.json").write_text("{}", encoding="utf-8")
+
+    model_config = object.__new__(ModelConfig)
+    model_config.model = str(model_path)
+    model_config.tokenizer = str(tokenizer_path)
+    model_config.hf_config_path = None
+
+    model_config._maybe_use_local_gguf_companion_config()
+
+    assert model_config.hf_config_path == str(tokenizer_path)
+
+
+def test_local_gguf_companion_config_keeps_explicit_hf_config_path(tmp_path):
+    model_path = tmp_path / "Qwen3.5-27B-Q6_K.gguf"
+    model_path.write_bytes(b"GGUF")
+    tokenizer_path = tmp_path / "Qwen3.5-27B-UD-Q6_K_XL-repo"
+    tokenizer_path.mkdir()
+    (tokenizer_path / "config.json").write_text("{}", encoding="utf-8")
+
+    model_config = object.__new__(ModelConfig)
+    model_config.model = str(model_path)
+    model_config.tokenizer = str(tokenizer_path)
+    model_config.hf_config_path = "/tmp/explicit-config"
+
+    model_config._maybe_use_local_gguf_companion_config()
+
+    assert model_config.hf_config_path == "/tmp/explicit-config"
+
+
+def test_qwen35_gguf_metadata_tokenizer_is_used(monkeypatch, tmp_path):
+    model_path = tmp_path / "Qwen3.6-27B-UD-Q4_K_XL.gguf"
+    model_path.write_bytes(b"GGUF")
+    tokenizer_path = tmp_path / "tokenizer-cache"
+
+    monkeypatch.setattr(
+        "vllm.config.model.qwen35_gguf_tokenizer_path",
+        lambda model: str(tokenizer_path),
+    )
+
+    model_config = object.__new__(ModelConfig)
+    model_config.model = str(model_path)
+    model_config.tokenizer = str(model_path)
+
+    model_config._maybe_use_qwen35_gguf_tokenizer()
+
+    assert model_config.tokenizer == str(tokenizer_path)
 
 
 @dataclass

--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -6,8 +6,189 @@ only get the `eos_token_id` from the tokenizer as defined by
 `vllm.LLMEngine._get_eos_token_id`.
 """
 
+import pytest
+
 from vllm.tokenizers import get_tokenizer
+from vllm.transformers_utils import config as config_utils
+from vllm.transformers_utils import gguf_utils
 from vllm.transformers_utils.config import try_get_generation_config
+
+
+def test_maybe_override_with_speculators_skips_unsupported_local_gguf_arch(
+    monkeypatch,
+    tmp_path,
+):
+    model = tmp_path / "qwen35.gguf"
+    model.write_bytes(b"GGUF")
+
+    def fail_get_config_dict(*args, **kwargs):
+        raise ValueError(
+            "GGUF model with architecture qwen35 is not supported yet."
+        )
+
+    monkeypatch.setattr(
+        config_utils.PretrainedConfig,
+        "get_config_dict",
+        fail_get_config_dict,
+    )
+
+    assert config_utils.maybe_override_with_speculators(
+        model=str(model),
+        tokenizer="/tmp/tokenizer",
+        trust_remote_code=False,
+    ) == (str(model), "/tmp/tokenizer", None)
+
+
+def test_maybe_override_with_speculators_reraises_hf_config_path_gguf_errors(
+    monkeypatch,
+    tmp_path,
+):
+    model = tmp_path / "qwen35.gguf"
+    model.write_bytes(b"GGUF")
+
+    def fail_get_config_dict(*args, **kwargs):
+        raise ValueError(
+            "GGUF model with architecture qwen35 is not supported yet."
+        )
+
+    monkeypatch.setattr(
+        config_utils.PretrainedConfig,
+        "get_config_dict",
+        fail_get_config_dict,
+    )
+
+    with pytest.raises(ValueError, match="architecture qwen35"):
+        config_utils.maybe_override_with_speculators(
+            model=str(model),
+            tokenizer="/tmp/tokenizer",
+            trust_remote_code=False,
+            hf_config_path="/tmp/hf-config",
+        )
+
+
+def test_get_config_builds_qwen35_config_from_local_gguf_metadata(
+    monkeypatch,
+    tmp_path,
+):
+    model = tmp_path / "qwen35.gguf"
+    model.write_bytes(b"GGUF")
+
+    def fail_get_config_dict(*args, **kwargs):
+        raise ValueError(
+            "GGUF model with architecture qwen35 is not supported yet."
+        )
+
+    config_dict = {
+        "architectures": ["Qwen3_5ForCausalLM"],
+        "model_type": "qwen3_5",
+        "text_config": {
+            "model_type": "qwen3_5_text",
+            "vocab_size": 248320,
+            "hidden_size": 5120,
+            "intermediate_size": 17408,
+            "num_hidden_layers": 65,
+            "num_attention_heads": 24,
+            "num_key_value_heads": 4,
+            "max_position_embeddings": 262144,
+            "rms_norm_eps": 1e-6,
+            "head_dim": 256,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128,
+            "linear_conv_kernel_dim": 4,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 24,
+            "full_attention_interval": 4,
+            "rope_parameters": {
+                "rope_type": "default",
+                "rope_theta": 10000000.0,
+                "mrope_section": [11, 11, 10, 0],
+                "mrope_interleaved": True,
+            },
+            "bos_token_id": 248044,
+            "eos_token_id": 248046,
+            "pad_token_id": 248055,
+            "tie_word_embeddings": False,
+        },
+    }
+
+    monkeypatch.setattr(
+        config_utils.PretrainedConfig,
+        "get_config_dict",
+        fail_get_config_dict,
+    )
+    monkeypatch.setattr(
+        config_utils,
+        "qwen35_gguf_config_dict",
+        lambda model: config_dict,
+    )
+
+    config = config_utils.get_config(str(model), trust_remote_code=False)
+
+    assert config.model_type == "qwen3_5"
+    assert config.architectures == ["Qwen3_5ForCausalLM"]
+    assert config.text_config.linear_num_value_heads == 24
+
+
+def test_qwen35_gguf_config_derives_value_heads_from_attn_qkv(
+    monkeypatch,
+    tmp_path,
+):
+    model = tmp_path / "qwen35-4b.gguf"
+    model.write_bytes(b"GGUF")
+
+    class FakeField:
+
+        def __init__(self, value):
+            self.value = value
+
+        def contents(self):
+            return self.value
+
+    class FakeTensor:
+
+        def __init__(self, name, shape):
+            self.name = name
+            self.shape = shape
+
+    class FakeReader:
+
+        tensors = [
+            FakeTensor("blk.0.attn_qkv.weight", (2560, 8192)),
+            FakeTensor("output.weight", (151936, 2560)),
+        ]
+
+        def get_field(self, key):
+            fields = {
+                "general.architecture": "qwen35",
+                "tokenizer.ggml.tokens": ["<pad>", "x"],
+                "qwen35.ssm.state_size": 128,
+                "qwen35.ssm.group_count": 16,
+                "qwen35.block_count": 1,
+                "qwen35.embedding_length": 2560,
+                "qwen35.feed_forward_length": 9728,
+                "qwen35.attention.head_count": 16,
+                "qwen35.attention.head_count_kv": 8,
+                "qwen35.context_length": 32768,
+                "qwen35.attention.layer_norm_rms_epsilon": 1e-6,
+                "qwen35.attention.key_length": 256,
+                "qwen35.ssm.conv_kernel": 4,
+                "qwen35.full_attention_interval": 4,
+                "qwen35.rope.freq_base": 1000000.0,
+                "qwen35.rope.dimension_sections": [8, 8, 8, 0],
+                "tokenizer.ggml.bos_token_id": 0,
+                "tokenizer.ggml.eos_token_id": 1,
+                "tokenizer.ggml.padding_token_id": 0,
+            }
+            if key not in fields:
+                return None
+            return FakeField(fields[key])
+
+    monkeypatch.setattr(gguf_utils.gguf, "GGUFReader", lambda _: FakeReader())
+
+    config_dict = gguf_utils.qwen35_gguf_config_dict(str(model))
+
+    assert config_dict is not None
+    assert config_dict["text_config"]["linear_num_value_heads"] == 32
 
 
 def test_get_llama3_eos_token():

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -337,6 +337,74 @@ def fused_add_rms_norm(
     torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
 
 
+def rms_norm_gated_gfx906(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    gate: torch.Tensor,
+    epsilon: float,
+    norm_before_gate: bool,
+) -> torch.Tensor:
+    return torch.ops._C.rms_norm_gated_gfx906(
+        input, weight, gate, epsilon, norm_before_gate
+    )
+
+
+if hasattr(torch.ops._C, "rms_norm_gated_gfx906"):
+
+    @register_fake("_C::rms_norm_gated_gfx906")
+    def _rms_norm_gated_gfx906_fake(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        gate: torch.Tensor,
+        epsilon: float,
+        norm_before_gate: bool,
+    ) -> torch.Tensor:
+        return torch.empty_like(input)
+
+
+def gemma_rms_norm_gfx906(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+) -> torch.Tensor:
+    return torch.ops._C.gemma_rms_norm_gfx906(input, weight, epsilon)
+
+
+def gemma_fused_add_rms_norm_gfx906(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    out, residual_out = torch.ops._C.gemma_fused_add_rms_norm_gfx906(
+        input, residual, weight, epsilon
+    )
+    return out, residual_out
+
+
+if hasattr(torch.ops._C, "gemma_rms_norm_gfx906"):
+
+    @register_fake("_C::gemma_rms_norm_gfx906")
+    def _gemma_rms_norm_gfx906_fake(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        epsilon: float,
+    ) -> torch.Tensor:
+        return torch.empty_like(input)
+
+
+if hasattr(torch.ops._C, "gemma_fused_add_rms_norm_gfx906"):
+
+    @register_fake("_C::gemma_fused_add_rms_norm_gfx906")
+    def _gemma_fused_add_rms_norm_gfx906_fake(
+        input: torch.Tensor,
+        residual: torch.Tensor,
+        weight: torch.Tensor,
+        epsilon: float,
+    ) -> list[torch.Tensor]:
+        return [torch.empty_like(input), torch.empty_like(residual, dtype=torch.float32)]
+
+
 def fused_qk_norm_rope(
     qkv: torch.Tensor,
     num_heads_q: int,
@@ -1752,6 +1820,14 @@ def ggml_mul_mat_vec_a8(
     return torch.ops._C.ggml_mul_mat_vec_a8(W, X, quant_type, row)
 
 
+def ggml_mul_mat_vec_a8_sharded(
+    W: list[torch.Tensor],
+    X: torch.Tensor,
+    quant_types: list[int],
+) -> torch.Tensor:
+    return torch.ops._C.ggml_mul_mat_vec_a8_sharded(W, X, quant_types)
+
+
 def ggml_mul_mat_a8(
     W: torch.Tensor,
     X: torch.Tensor,
@@ -1799,6 +1875,204 @@ def ggml_moe_a8_vec(
 
 def ggml_moe_get_block_size(quant_type: int) -> int:
     return torch.ops._C.ggml_moe_get_block_size(quant_type)
+
+
+if hasattr(torch.ops._C, "causal_conv1d_gfx906_decode_update"):
+
+    @register_fake("_C::causal_conv1d_gfx906_decode_update")
+    def _causal_conv1d_gfx906_decode_update_fake(
+        x: torch.Tensor,
+        conv_state: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None,
+        conv_state_indices: torch.Tensor | None,
+        pad_slot_id: int,
+        silu_activation: bool,
+    ) -> torch.Tensor:
+        return torch.empty_like(x)
+
+
+if hasattr(torch.ops._C, "fused_sigmoid_gating_delta_rule_gfx906_decode"):
+
+    @register_fake("_C::fused_sigmoid_gating_delta_rule_gfx906_decode")
+    def _fused_sigmoid_gating_delta_rule_gfx906_decode_fake(
+        A_log: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        dt_bias: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        state: torch.Tensor,
+        beta: float,
+        threshold: float,
+        scale: float,
+        use_qk_l2norm_in_kernel: bool,
+    ) -> torch.Tensor:
+        return torch.empty((1, q.size(1), v.size(2), v.size(3)),
+                           dtype=q.dtype,
+                           device=q.device)
+
+
+if hasattr(torch.ops._C, "fused_sigmoid_gating_delta_rule_gfx906_indexed_decode"):
+
+    @register_fake("_C::fused_sigmoid_gating_delta_rule_gfx906_indexed_decode")
+    def _fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_fake(
+        A_log: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        dt_bias: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        state: torch.Tensor,
+        state_indices: torch.Tensor,
+        beta: float,
+        threshold: float,
+        scale: float,
+        use_qk_l2norm_in_kernel: bool,
+    ) -> torch.Tensor:
+        return torch.empty((1, q.size(1), v.size(2), v.size(3)),
+                           dtype=q.dtype,
+                           device=q.device)
+
+
+if hasattr(torch.ops._C,
+           "fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state"):
+
+    @register_fake(
+        "_C::fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state")
+    def _fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state_fake(
+        A_log: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        dt_bias: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        state: torch.Tensor,
+        state_indices: torch.Tensor,
+        beta: float,
+        threshold: float,
+        scale: float,
+        use_qk_l2norm_in_kernel: bool,
+    ) -> torch.Tensor:
+        return torch.empty((1, q.size(1), v.size(2), v.size(3)),
+                           dtype=q.dtype,
+                           device=q.device)
+
+
+if hasattr(torch.ops._C, "fused_recurrent_gated_delta_rule_gfx906_packed_decode"):
+
+    @register_fake("_C::fused_recurrent_gated_delta_rule_gfx906_packed_decode")
+    def _fused_recurrent_gated_delta_rule_gfx906_packed_decode_fake(
+        mixed_qkv: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        state: torch.Tensor,
+        out: torch.Tensor,
+        state_indices: torch.Tensor,
+        scale: float,
+        use_qk_l2norm_in_kernel: bool,
+        use_tiled_qk_head_mapping: bool,
+        use_transposed_state: bool,
+    ) -> torch.Tensor:
+        return torch.empty_like(out)
+
+
+def causal_conv1d_gfx906_decode_update(
+    x: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_state_indices: torch.Tensor | None,
+    pad_slot_id: int,
+    silu_activation: bool,
+) -> torch.Tensor:
+    return torch.ops._C.causal_conv1d_gfx906_decode_update(
+        x, conv_state, weight, bias, conv_state_indices, pad_slot_id,
+        silu_activation)
+
+
+def fused_sigmoid_gating_delta_rule_gfx906_decode(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    state: torch.Tensor,
+    beta: float,
+    threshold: float,
+    scale: float,
+    use_qk_l2norm_in_kernel: bool,
+) -> torch.Tensor:
+    return torch.ops._C.fused_sigmoid_gating_delta_rule_gfx906_decode(
+        A_log, a, b, dt_bias, q, k, v, state, beta, threshold, scale,
+        use_qk_l2norm_in_kernel)
+
+
+def fused_sigmoid_gating_delta_rule_gfx906_indexed_decode(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    state: torch.Tensor,
+    state_indices: torch.Tensor,
+    beta: float,
+    threshold: float,
+    scale: float,
+    use_qk_l2norm_in_kernel: bool,
+) -> torch.Tensor:
+    return torch.ops._C.fused_sigmoid_gating_delta_rule_gfx906_indexed_decode(
+        A_log, a, b, dt_bias, q, k, v, state, state_indices, beta, threshold,
+        scale, use_qk_l2norm_in_kernel)
+
+
+def fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    state: torch.Tensor,
+    state_indices: torch.Tensor,
+    beta: float,
+    threshold: float,
+    scale: float,
+    use_qk_l2norm_in_kernel: bool,
+) -> torch.Tensor:
+    return torch.ops._C.fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state(
+        A_log, a, b, dt_bias, q, k, v, state, state_indices, beta, threshold,
+        scale, use_qk_l2norm_in_kernel)
+
+
+def fused_recurrent_gated_delta_rule_gfx906_packed_decode(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    state: torch.Tensor,
+    out: torch.Tensor,
+    state_indices: torch.Tensor,
+    scale: float,
+    use_qk_l2norm_in_kernel: bool,
+    use_tiled_qk_head_mapping: bool,
+    use_transposed_state: bool,
+) -> torch.Tensor:
+    return torch.ops._C.fused_recurrent_gated_delta_rule_gfx906_packed_decode(
+        mixed_qkv, a, b, A_log, dt_bias, state, out, state_indices, scale,
+        use_qk_l2norm_in_kernel, use_tiled_qk_head_mapping,
+        use_transposed_state)
 
 
 # mamba

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -38,6 +38,7 @@ from vllm.platforms import current_platform
 from vllm.transformers_utils.gguf_utils import (
     detect_gguf_multimodal,
     maybe_patch_hf_config_from_gguf,
+    qwen35_gguf_tokenizer_path,
 )
 from vllm.transformers_utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 from vllm.transformers_utils.utils import (
@@ -527,6 +528,30 @@ class ModelConfig:
             self.tokenizer = str(candidates[0])
             logger.info("Using local GGUF companion tokenizer: %s", self.tokenizer)
 
+    def _maybe_use_local_gguf_companion_config(self) -> None:
+        if self.hf_config_path is not None or not check_gguf_file(self.model):
+            return
+
+        if self.tokenizer is None or self.tokenizer == self.model:
+            return
+
+        tokenizer_path = Path(self.tokenizer)
+        if not tokenizer_path.is_dir():
+            return
+
+        if (tokenizer_path / "config.json").is_file():
+            self.hf_config_path = str(tokenizer_path)
+            logger.info("Using local GGUF companion config: %s", self.hf_config_path)
+
+    def _maybe_use_qwen35_gguf_tokenizer(self) -> None:
+        if self.tokenizer is None or self.tokenizer != self.model:
+            return
+
+        tokenizer_path = qwen35_gguf_tokenizer_path(self.model)
+        if tokenizer_path is not None:
+            self.tokenizer = tokenizer_path
+            logger.info("Using qwen35 GGUF metadata tokenizer: %s", self.tokenizer)
+
     def __post_init__(
         self,
         # Multimodal config init vars
@@ -560,12 +585,14 @@ class ModelConfig:
         if self.tokenizer is None:
             self.tokenizer = self.model
         self._maybe_use_local_gguf_companion_tokenizer()
+        self._maybe_use_qwen35_gguf_tokenizer()
         if self.tokenizer_revision is None:
             self.tokenizer_revision = self.revision
         self.tokenizer = maybe_model_redirect(self.tokenizer)
 
         if isinstance(self.hf_config_path, str):
             self.hf_config_path = maybe_model_redirect(self.hf_config_path)
+        self._maybe_use_local_gguf_companion_config()
 
         if callable(self.hf_overrides):
             hf_overrides_kw = {}

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -93,6 +93,36 @@ def enable_fusion(cfg: "VllmConfig") -> bool:
     ) or cfg.compilation_config.is_custom_op_enabled("quant_fp8")
 
 
+def _is_gfx906_qwen35_gguf(model_config: ModelConfig | None) -> bool:
+    if model_config is None or model_config.quantization != "gguf":
+        return False
+
+    hf_config = model_config.hf_text_config
+    if getattr(hf_config, "model_type", None) not in {
+        "qwen3_5",
+        "qwen3_5_text",
+    }:
+        return False
+
+    from vllm.platforms import current_platform
+
+    capability = current_platform.get_device_capability()
+    major = getattr(capability, "major", None)
+    minor = getattr(capability, "minor", None)
+    if isinstance(capability, tuple):
+        major, minor = capability[:2]
+    return (
+        current_platform.is_rocm()
+        and capability is not None
+        and major == 9
+        and minor == 0
+    )
+
+
+def needs_qwen35_gguf_piecewise_cudagraph(model_config: ModelConfig | None) -> bool:
+    return _is_gfx906_qwen35_gguf(model_config)
+
+
 OPTIMIZATION_LEVEL_00 = {
     "compilation_config": {
         "pass_config": {
@@ -688,6 +718,14 @@ class VllmConfig:
                         logger.warning_once(
                             "Encoder-decoder models do not support full cudagraphs. "
                             "Overriding cudagraph_mode to PIECEWISE."
+                        )
+                        self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+                    elif needs_qwen35_gguf_piecewise_cudagraph(self.model_config):
+                        logger.warning_once(
+                            "Qwen3.5 GGUF on gfx906 updates GatedDeltaNet state "
+                            "through a custom op that is not safe under full "
+                            "decode CUDA graphs. Overriding cudagraph_mode to "
+                            "PIECEWISE."
                         )
                         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1565,6 +1565,7 @@ async def init_app_state(
             tool_parser=args.tool_call_parser,
             tool_server=tool_server,
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
+            default_chat_template_kwargs=args.default_chat_template_kwargs,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
             enable_log_outputs=args.enable_log_outputs,
@@ -1587,6 +1588,7 @@ async def init_app_state(
             exclude_tools_when_tool_choice_none=args.exclude_tools_when_tool_choice_none,
             tool_parser=args.tool_call_parser,
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
+            default_chat_template_kwargs=args.default_chat_template_kwargs,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
             enable_log_outputs=args.enable_log_outputs,
@@ -1618,6 +1620,7 @@ async def init_app_state(
                 chat_template=resolved_chat_template,
                 chat_template_content_format=args.chat_template_content_format,
                 trust_request_chat_template=args.trust_request_chat_template,
+                default_chat_template_kwargs=args.default_chat_template_kwargs,
                 log_error_stack=args.log_error_stack,
             )
         )
@@ -1632,6 +1635,7 @@ async def init_app_state(
             chat_template=resolved_chat_template,
             chat_template_content_format=args.chat_template_content_format,
             trust_request_chat_template=args.trust_request_chat_template,
+            default_chat_template_kwargs=args.default_chat_template_kwargs,
             log_error_stack=args.log_error_stack,
         )
         if "embed" in supported_tasks
@@ -1645,6 +1649,7 @@ async def init_app_state(
             chat_template=resolved_chat_template,
             chat_template_content_format=args.chat_template_content_format,
             trust_request_chat_template=args.trust_request_chat_template,
+            default_chat_template_kwargs=args.default_chat_template_kwargs,
             log_error_stack=args.log_error_stack,
         )
         if "classify" in supported_tasks
@@ -1667,6 +1672,7 @@ async def init_app_state(
         chat_template=resolved_chat_template,
         chat_template_content_format=args.chat_template_content_format,
         trust_request_chat_template=args.trust_request_chat_template,
+        default_chat_template_kwargs=args.default_chat_template_kwargs,
         log_error_stack=args.log_error_stack,
     )
     state.openai_serving_transcription = (

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -11,7 +11,7 @@ import json
 import ssl
 from collections.abc import Sequence
 from dataclasses import field
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic.dataclasses import dataclass
 
@@ -114,6 +114,10 @@ class FrontendArgs:
     """Whether to trust the chat template provided in the request. If False,
     the server will always use the chat template specified by `--chat-template`
     or the ones from tokenizer."""
+    default_chat_template_kwargs: dict[str, Any] | None = None
+    """Default keyword arguments to pass to the chat template renderer. These
+    will be merged with request-level chat_template_kwargs, with request values
+    taking precedence."""
     response_role: str = "assistant"
     """The role name to return if `request.add_generation_prompt=true`."""
     ssl_keyfile: str | None = None
@@ -200,6 +204,9 @@ class FrontendArgs:
         from vllm.engine.arg_utils import get_kwargs
 
         frontend_kwargs = get_kwargs(FrontendArgs)
+
+        # Special case: default_chat_template_kwargs needs json.loads type
+        frontend_kwargs["default_chat_template_kwargs"]["type"] = json.loads
 
         # Special case: allowed_origins, allowed_methods, allowed_headers all
         # need json.loads type

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -345,6 +345,13 @@ class ResponsesRequest(OpenAIBaseModel):
         default=None,
         description=("Additional kwargs to pass to the HF processor."),
     )
+    chat_template_kwargs: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Additional keyword args to pass to the template renderer. "
+            "Will be accessible by the chat template."
+        ),
+    )
     priority: int = Field(
         default=0,
         description=(

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -6,7 +6,7 @@ import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
-from typing import Final
+from typing import Any, Final
 
 import jinja2
 import partial_json_parser
@@ -87,6 +87,7 @@ class OpenAIServingChat(OpenAIServing):
         chat_template_content_format: ChatTemplateContentFormatOption,
         trust_request_chat_template: bool = False,
         return_tokens_as_token_ids: bool = False,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
         reasoning_parser: str = "",
         enable_auto_tools: bool = False,
         exclude_tools_when_tool_choice_none: bool = False,
@@ -101,6 +102,7 @@ class OpenAIServingChat(OpenAIServing):
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
+            default_chat_template_kwargs=default_chat_template_kwargs,
             log_error_stack=log_error_stack,
         )
 
@@ -587,7 +589,10 @@ class OpenAIServingChat(OpenAIServing):
             if self.reasoning_parser:
                 reasoning_parser = self.reasoning_parser(
                     tokenizer,
-                    chat_template_kwargs=request.chat_template_kwargs,  # type: ignore
+                    chat_template_kwargs=self._get_effective_chat_template_kwargs(
+                        request.chat_template_kwargs,
+                        request,
+                    ),  # type: ignore
                 )
         except RuntimeError as e:
             logger.exception("Error in reasoning parser creation.")
@@ -595,6 +600,35 @@ class OpenAIServingChat(OpenAIServing):
             yield f"data: {data}\n\n"
             yield "data: [DONE]\n\n"
             return
+
+        def is_reasoning_end_streaming(
+            parser,
+            current_token_ids: list[int],
+            delta_token_ids: list[int],
+        ) -> bool:
+            if getattr(parser, "engine_based_streaming", False):
+                return parser.has_engine_confirmed_reasoning_end()
+            return parser.is_reasoning_end_streaming(
+                current_token_ids,
+                delta_token_ids,
+            )
+
+        def merge_delta_message(
+            base: DeltaMessage | None,
+            extra: DeltaMessage | None,
+        ) -> DeltaMessage | None:
+            if extra is None:
+                return base
+            if base is None:
+                return extra
+            if extra.content:
+                base.content = (base.content or "") + extra.content
+            if extra.reasoning:
+                base.reasoning = (base.reasoning or "") + extra.reasoning
+            if extra.tool_calls:
+                base.tool_calls.extend(extra.tool_calls)
+            return base
+
         # Prepare the tool parser if it's needed
         try:
             if tool_choice_auto and self.tool_parser:
@@ -843,8 +877,11 @@ class OpenAIServingChat(OpenAIServing):
                             # i.e {"enable_thinking": False},
                             # set reasoning status to end.
                             # Only keep 'content', remove 'reasoning'.
-                            if reasoning_parser.is_reasoning_end(
-                                as_list(output.token_ids)
+                            output_token_ids = as_list(output.token_ids)
+                            if is_reasoning_end_streaming(
+                                reasoning_parser,
+                                current_token_ids,
+                                output_token_ids,
                             ) or (
                                 res.prompt_token_ids
                                 and reasoning_parser.is_reasoning_end(
@@ -914,7 +951,11 @@ class OpenAIServingChat(OpenAIServing):
                                     output_token_ids,
                                 )
                             )
-                            if reasoning_parser.is_reasoning_end(output_token_ids):
+                            if is_reasoning_end_streaming(
+                                reasoning_parser,
+                                current_token_ids,
+                                output_token_ids,
+                            ):
                                 reasoning_end_arr[i] = True
                                 if delta_message and delta_message.content:
                                     current_text = delta_message.content
@@ -985,7 +1026,11 @@ class OpenAIServingChat(OpenAIServing):
                             # set reasoning status to end.
                             # Remove the text and token ids related
                             # to 'reasoning'.
-                            if reasoning_parser.is_reasoning_end(output_token_ids):
+                            if is_reasoning_end_streaming(
+                                reasoning_parser,
+                                current_token_ids,
+                                output_token_ids,
+                            ):
                                 reasoning_end_arr[i] = True
                                 current_token_ids = (
                                     reasoning_parser.extract_content_ids(
@@ -1047,6 +1092,14 @@ class OpenAIServingChat(OpenAIServing):
                             current_token_ids,
                             output.token_ids,
                         )
+                        if (
+                            output.finish_reason is not None
+                            and getattr(reasoning_parser, "engine_based_streaming", False)
+                        ):
+                            delta_message = merge_delta_message(
+                                delta_message,
+                                reasoning_parser.finish_streaming(),
+                            )
                     # handle streaming just a content delta
                     else:
                         delta_message = DeltaMessage(content=delta_text)
@@ -1388,7 +1441,10 @@ class OpenAIServingChat(OpenAIServing):
                 try:
                     reasoning_parser = self.reasoning_parser(
                         tokenizer,
-                        chat_template_kwargs=request.chat_template_kwargs,  # type: ignore
+                        chat_template_kwargs=self._get_effective_chat_template_kwargs(
+                            request.chat_template_kwargs,
+                            request,
+                        ),  # type: ignore
                     )
                 except RuntimeError as e:
                     logger.exception("Error in reasoning parser creation.")

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -260,6 +260,7 @@ class OpenAIServing:
         *,
         request_logger: RequestLogger | None,
         return_tokens_as_token_ids: bool = False,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
         log_error_stack: bool = False,
     ):
         super().__init__()
@@ -270,6 +271,7 @@ class OpenAIServing:
 
         self.request_logger = request_logger
         self.return_tokens_as_token_ids = return_tokens_as_token_ids
+        self.default_chat_template_kwargs = default_chat_template_kwargs or {}
         self._tokenizer_executor = ThreadPoolExecutor(max_workers=1)
         self._apply_mistral_chat_template_async = make_async(
             apply_mistral_chat_template, executor=self._tokenizer_executor
@@ -282,6 +284,34 @@ class OpenAIServing:
         self.io_processor = self.models.io_processor
         self.model_config = self.models.model_config
         self.max_model_len = self.model_config.max_model_len
+
+    def _get_effective_chat_template_kwargs(
+        self,
+        request_chat_template_kwargs: dict[str, Any] | None,
+        request: Any | None = None,
+    ) -> dict[str, Any] | None:
+        extra_kwargs: dict[str, Any] = {}
+        reasoning_effort = getattr(request, "reasoning_effort", None)
+        if reasoning_effort is None:
+            reasoning = getattr(request, "reasoning", None)
+            reasoning_effort = getattr(reasoning, "effort", None)
+
+        user_kwargs = request_chat_template_kwargs or {}
+        if reasoning_effort is not None and "enable_thinking" not in user_kwargs:
+            extra_kwargs["enable_thinking"] = reasoning_effort != "none"
+
+        if not self.default_chat_template_kwargs:
+            if not extra_kwargs:
+                return request_chat_template_kwargs
+            return {
+                **extra_kwargs,
+                **user_kwargs,
+            }
+        return {
+            **self.default_chat_template_kwargs,
+            **extra_kwargs,
+            **(request_chat_template_kwargs or {}),
+        }
 
     def _get_tool_parser(
         self, tool_parser_name: str | None = None, enable_auto_tools: bool = False
@@ -1117,7 +1147,10 @@ class OpenAIServing:
             tools=tool_dicts,
             documents=documents,
         )
-        _chat_template_kwargs.update(chat_template_kwargs or {})
+        _chat_template_kwargs.update(
+            self._get_effective_chat_template_kwargs(chat_template_kwargs, request)
+            or {}
+        )
 
         request_prompt: str | list[int]
 
@@ -1145,6 +1178,22 @@ class OpenAIServing:
         should_parse_tools = tool_parser is not None and (
             hasattr(request, "tool_choice") and request.tool_choice != "none"
         )
+
+        reasoning_parser = getattr(self, "reasoning_parser", None)
+        if reasoning_parser is not None:
+            if not isinstance(request, ChatCompletionRequest | ResponsesRequest):
+                msg = (
+                    "Reasoning parsing is only supported for Chat Completions "
+                    "API or Responses API requests."
+                )
+                raise NotImplementedError(msg)
+            request = reasoning_parser(
+                tokenizer,
+                chat_template_kwargs=self._get_effective_chat_template_kwargs(
+                    chat_template_kwargs,
+                    request,
+                ),
+            ).adjust_request(request=request)
 
         if should_parse_tools:
             if not isinstance(request, ChatCompletionRequest | ResponsesRequest):

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
 from contextlib import AsyncExitStack
 from copy import copy
 from http import HTTPStatus
-from typing import Final
+from typing import Any, Final
 
 import jinja2
 from fastapi import Request
@@ -161,6 +161,7 @@ class OpenAIServingResponses(OpenAIServing):
         chat_template: str | None,
         chat_template_content_format: ChatTemplateContentFormatOption,
         return_tokens_as_token_ids: bool = False,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
         reasoning_parser: str = "",
         enable_auto_tools: bool = False,
         tool_parser: str | None = None,
@@ -175,6 +176,7 @@ class OpenAIServingResponses(OpenAIServing):
             models=models,
             request_logger=request_logger,
             return_tokens_as_token_ids=return_tokens_as_token_ids,
+            default_chat_template_kwargs=default_chat_template_kwargs,
             log_error_stack=log_error_stack,
         )
 
@@ -416,7 +418,12 @@ class OpenAIServingResponses(OpenAIServing):
                     context = SimpleContext()
 
                 if self.reasoning_parser is not None:
-                    reasoning_parser = self.reasoning_parser(tokenizer)
+                    reasoning_parser = self.reasoning_parser(
+                        tokenizer,
+                        chat_template_kwargs=self._get_effective_chat_template_kwargs(
+                            request.chat_template_kwargs, request
+                        ),
+                    )
                     if sampling_params.structured_outputs is None:
                         sampling_params.structured_outputs = StructuredOutputsParams()
                     struct_out = sampling_params.structured_outputs
@@ -550,6 +557,9 @@ class OpenAIServingResponses(OpenAIServing):
             prev_msg=self.msg_store.get(prev_response.id) if prev_response else None,
             prev_response_output=prev_response.output if prev_response else None,
         )
+        chat_template_kwargs = self._get_effective_chat_template_kwargs(
+            request.chat_template_kwargs, request
+        )
         _, request_prompts, engine_prompts = await self._preprocess_chat(
             request,
             tokenizer,
@@ -558,6 +568,7 @@ class OpenAIServingResponses(OpenAIServing):
             tool_parser=self.tool_parser,
             chat_template=self.chat_template,
             chat_template_content_format=self.chat_template_content_format,
+            chat_template_kwargs=chat_template_kwargs,
         )
         return messages, request_prompts, engine_prompts
 
@@ -807,7 +818,12 @@ class OpenAIServingResponses(OpenAIServing):
     ) -> list[ResponseOutputItem]:
         if self.reasoning_parser:
             try:
-                reasoning_parser = self.reasoning_parser(tokenizer)
+                reasoning_parser = self.reasoning_parser(
+                    tokenizer,
+                    chat_template_kwargs=self._get_effective_chat_template_kwargs(
+                        request.chat_template_kwargs, request
+                    ),
+                )
             except RuntimeError as e:
                 logger.exception("Error in reasoning parser creation.")
                 raise e
@@ -1194,7 +1210,12 @@ class OpenAIServingResponses(OpenAIServing):
         current_item_id = ""
         reasoning_parser = None
         if self.reasoning_parser:
-            reasoning_parser = self.reasoning_parser(tokenizer)
+            reasoning_parser = self.reasoning_parser(
+                tokenizer,
+                chat_template_kwargs=self._get_effective_chat_template_kwargs(
+                    request.chat_template_kwargs, request
+                ),
+            )
         previous_text = ""
         previous_token_ids: list[int] = []
         first_delta_sent = False

--- a/vllm/entrypoints/openai/serving_tokenization.py
+++ b/vllm/entrypoints/openai/serving_tokenization.py
@@ -37,12 +37,14 @@ class OpenAIServingTokenization(OpenAIServing):
         chat_template: str | None,
         chat_template_content_format: ChatTemplateContentFormatOption,
         trust_request_chat_template: bool = False,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
         log_error_stack: bool = False,
     ) -> None:
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
+            default_chat_template_kwargs=default_chat_template_kwargs,
             log_error_stack=log_error_stack,
         )
 

--- a/vllm/entrypoints/openai/tool_parsers/utils.py
+++ b/vllm/entrypoints/openai/tool_parsers/utils.py
@@ -145,6 +145,171 @@ def _extract_tool_info(
         raise TypeError(f"Unsupported tool type: {type(tool)}")
 
 
+def _is_function_tool(tool: Tool | ChatCompletionToolsParam) -> bool:
+    return isinstance(tool, (FunctionTool, ChatCompletionToolsParam))
+
+
+def find_tool_properties(
+    tools: list[Tool | ChatCompletionToolsParam] | None,
+    tool_name: str,
+) -> dict[str, Any]:
+    """Find a tool by name and return its properties dict, or {}."""
+    if not tools:
+        return {}
+    for tool in tools:
+        if not _is_function_tool(tool):
+            continue
+        name, params = _extract_tool_info(tool)
+        if name == tool_name:
+            return (params or {}).get("properties", {})
+    return {}
+
+
+def find_tool_name(
+    tools: list[Tool | ChatCompletionToolsParam] | None,
+    tool_name: str,
+) -> bool:
+    """Return whether a function tool with *tool_name* exists."""
+    if not tools:
+        return False
+    for tool in tools:
+        if not _is_function_tool(tool):
+            continue
+        name, _ = _extract_tool_info(tool)
+        if name == tool_name:
+            return True
+    return False
+
+
+def extract_types_from_schema(schema: Any) -> list[str]:
+    """Extract possible JSON Schema type strings."""
+    if schema is None or not isinstance(schema, dict):
+        return ["string"]
+
+    types: set[str] = set()
+    type_value = schema.get("type")
+    if isinstance(type_value, str):
+        types.add(type_value)
+    elif isinstance(type_value, list):
+        types.update(t for t in type_value if isinstance(t, str))
+
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and enum_values:
+        for value in enum_values:
+            if value is None:
+                types.add("null")
+            elif isinstance(value, bool):
+                types.add("boolean")
+            elif isinstance(value, int):
+                types.add("integer")
+            elif isinstance(value, float):
+                types.add("number")
+            elif isinstance(value, str):
+                types.add("string")
+            elif isinstance(value, list):
+                types.add("array")
+            elif isinstance(value, dict):
+                types.add("object")
+
+    for choice_field in ("anyOf", "oneOf", "allOf"):
+        choices = schema.get(choice_field)
+        if isinstance(choices, list):
+            for choice in choices:
+                types.update(extract_types_from_schema(choice))
+
+    return list(types) if types else ["string"]
+
+
+_TYPE_ALIASES: dict[str, str] = {
+    "str": "string",
+    "text": "string",
+    "varchar": "string",
+    "char": "string",
+    "enum": "string",
+    "int": "integer",
+    "int32": "integer",
+    "int64": "integer",
+    "uint": "integer",
+    "uint32": "integer",
+    "uint64": "integer",
+    "long": "integer",
+    "short": "integer",
+    "unsigned": "integer",
+    "float": "number",
+    "float32": "number",
+    "float64": "number",
+    "double": "number",
+    "bool": "boolean",
+    "dict": "object",
+    "arr": "array",
+    "list": "array",
+    "sequence": "array",
+}
+
+
+def coerce_to_schema_type(value: str, schema_type: str | list[str]) -> Any:
+    """Best-effort coercion of a raw string value to a JSON Schema type."""
+    if isinstance(schema_type, str):
+        schema_type = [schema_type]
+
+    normalized_types = {
+        _TYPE_ALIASES.get(key, key)
+        for t in schema_type
+        for key in [t.strip().lower()]
+    }
+    type_priority = [
+        "null",
+        "integer",
+        "number",
+        "boolean",
+        "object",
+        "array",
+        "string",
+    ]
+
+    for candidate_type in type_priority:
+        if candidate_type not in normalized_types:
+            continue
+        if candidate_type == "null":
+            if value.lower() == "null":
+                return None
+            continue
+        if candidate_type == "string":
+            return value
+        if candidate_type == "integer":
+            try:
+                if value.strip().isdigit() or (
+                    value.strip().startswith("-") and value.strip()[1:].isdigit()
+                ):
+                    return int(value)
+            except ValueError:
+                pass
+            continue
+        if candidate_type == "number":
+            try:
+                return float(value)
+            except ValueError:
+                continue
+        if candidate_type == "boolean":
+            lowered = value.lower()
+            if lowered == "true":
+                return True
+            if lowered == "false":
+                return False
+            continue
+        if candidate_type in ("object", "array"):
+            try:
+                parsed = json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if candidate_type == "object" and isinstance(parsed, dict):
+                return parsed
+            if candidate_type == "array" and isinstance(parsed, list):
+                return parsed
+
+    return value
+
+
 def _get_tool_schema_from_tool(tool: Tool | ChatCompletionToolsParam) -> dict:
     name, params = _extract_tool_info(tool)
     params = params if params else {"type": "object", "properties": {}}

--- a/vllm/entrypoints/pooling/classify/serving.py
+++ b/vllm/entrypoints/pooling/classify/serving.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from http import HTTPStatus
-from typing import cast
+from typing import Any, cast
 
 import jinja2
 import numpy as np
@@ -90,6 +90,7 @@ class ClassificationMixin(OpenAIServing):
                     ),
                     add_generation_prompt=False,
                     continue_final_message=False,
+                    chat_template_kwargs=chat_request.chat_template_kwargs,
                     add_special_tokens=chat_request.add_special_tokens,
                 )
                 ctx.engine_prompts = engine_prompts
@@ -191,12 +192,14 @@ class ServingClassification(ClassificationMixin):
         chat_template: str | None = None,
         chat_template_content_format: ChatTemplateContentFormatOption = "auto",
         trust_request_chat_template: bool = False,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
         log_error_stack: bool = False,
     ) -> None:
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
+            default_chat_template_kwargs=default_chat_template_kwargs,
             log_error_stack=log_error_stack,
         )
 

--- a/vllm/entrypoints/pooling/embed/serving.py
+++ b/vllm/entrypoints/pooling/embed/serving.py
@@ -625,12 +625,14 @@ class OpenAIServingEmbedding(EmbeddingMixin):
         chat_template: str | None,
         chat_template_content_format: ChatTemplateContentFormatOption,
         trust_request_chat_template: bool = False,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
         log_error_stack: bool = False,
     ) -> None:
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
+            default_chat_template_kwargs=default_chat_template_kwargs,
             log_error_stack=log_error_stack,
         )
 

--- a/vllm/entrypoints/pooling/pooling/serving.py
+++ b/vllm/entrypoints/pooling/pooling/serving.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 import time
 from collections.abc import AsyncGenerator, Sequence
-from typing import Final, cast
+from typing import Any, Final, cast
 
 import jinja2
 from fastapi import Request
@@ -58,12 +58,14 @@ class OpenAIServingPooling(OpenAIServing):
         chat_template: str | None,
         chat_template_content_format: ChatTemplateContentFormatOption,
         trust_request_chat_template: bool = False,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
         log_error_stack: bool = False,
     ) -> None:
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
+            default_chat_template_kwargs=default_chat_template_kwargs,
             log_error_stack=log_error_stack,
         )
 
@@ -151,6 +153,7 @@ class OpenAIServingPooling(OpenAIServing):
                     # so there is no need to append extra tokens to the input
                     add_generation_prompt=False,
                     continue_final_message=False,
+                    chat_template_kwargs=request.chat_template_kwargs,
                     add_special_tokens=request.add_special_tokens,
                 )
             elif isinstance(request, PoolingCompletionRequest):

--- a/vllm/model_executor/layers/fla/ops/__init__.py
+++ b/vllm/model_executor/layers/fla/ops/__init__.py
@@ -11,7 +11,10 @@ from .fused_recurrent import (
     fused_recurrent_gated_delta_rule,
     fused_recurrent_gated_delta_rule_packed_decode,
 )
-from .fused_sigmoid_gating import fused_sigmoid_gating_delta_rule_update
+from .fused_sigmoid_gating import (
+    fused_sigmoid_gating_delta_rule_update,
+    fused_sigmoid_gating_delta_rule_update_kv_cache_gfx906,
+)
 from .layernorm_guard import RMSNormGated
 
 __all__ = [
@@ -20,4 +23,5 @@ __all__ = [
     "fused_recurrent_gated_delta_rule",
     "fused_recurrent_gated_delta_rule_packed_decode",
     "fused_sigmoid_gating_delta_rule_update",
+    "fused_sigmoid_gating_delta_rule_update_kv_cache_gfx906",
 ]

--- a/vllm/model_executor/layers/fla/ops/chunk.py
+++ b/vllm/model_executor/layers/fla/ops/chunk.py
@@ -391,7 +391,7 @@ def chunk_gated_delta_rule(
     if scale is None:
         scale = k.shape[-1] ** -0.5
     if _is_gfx906_rocm():
-        return _chunk_gated_delta_rule_gfx906_eager(
+        o, final_state = _chunk_gated_delta_rule_gfx906_eager(
             q=q,
             k=k,
             v=v,
@@ -402,6 +402,9 @@ def chunk_gated_delta_rule(
             cu_seqlens=cu_seqlens,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
         )
+        if head_first:
+            o = rearrange(o, "b t h ... -> b h t ...")
+        return o, final_state
     o, final_state = ChunkGatedDeltaRuleFunction.apply(
         q,
         k,

--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -10,6 +10,7 @@
 
 import torch
 
+from vllm import _custom_ops as ops
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
@@ -477,8 +478,29 @@ def fused_recurrent_gated_delta_rule_packed_decode(
     out: torch.Tensor,
     ssm_state_indices: torch.Tensor,
     use_qk_l2norm_in_kernel: bool = False,
+    use_tiled_qk_head_mapping: bool = False,
+    use_transposed_state: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if _is_gfx906_rocm():
+        try:
+            output = ops.fused_recurrent_gated_delta_rule_gfx906_packed_decode(
+                mixed_qkv=mixed_qkv,
+                a=a,
+                b=b,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                state=initial_state,
+                out=out,
+                state_indices=ssm_state_indices,
+                scale=scale,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+                use_tiled_qk_head_mapping=use_tiled_qk_head_mapping,
+                use_transposed_state=use_transposed_state,
+            )
+            return output, initial_state
+        except (AttributeError, RuntimeError):
+            pass
+
         B = mixed_qkv.shape[0]
         HV, V, K = initial_state.shape[-3:]
         qkv_dim = mixed_qkv.shape[1]
@@ -497,6 +519,11 @@ def fused_recurrent_gated_delta_rule_packed_decode(
             raise ValueError(
                 f"Invalid head config inferred from mixed_qkv: H={H}, HV={HV}."
             )
+        if use_transposed_state and K != V:
+            raise ValueError(
+                "Packed decode with transposed cache state requires K == V "
+                f"(got K={K}, V={V})."
+            )
 
         state_indices = ssm_state_indices.to(dtype=torch.long)
         valid_mask = state_indices >= 0
@@ -506,7 +533,10 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         final_state = initial_state
 
         for head_idx in range(HV):
-            q_head_idx = head_idx // head_ratio
+            if use_tiled_qk_head_mapping:
+                q_head_idx = head_idx % H
+            else:
+                q_head_idx = head_idx // head_ratio
             q_offset = q_head_idx * K
             k_offset = H * K + q_head_idx * K
             v_offset = 2 * H * K + head_idx * V
@@ -528,11 +558,20 @@ def fused_recurrent_gated_delta_rule_packed_decode(
             state_view = final_state[:, head_idx]
             state_head = state_view.index_select(0, safe_indices).float()
             state_head = state_head * torch.exp(g_val).view(B, 1, 1)
-            v_residual = v_t - torch.sum(state_head * k_t[:, None, :], dim=2)
-            v_residual = v_residual * beta_val.view(B, 1)
-            state_head = state_head + v_residual[:, :, None] * k_t[:, None, :]
-
-            head_out = torch.sum(state_head * q_t[:, None, :], dim=2).to(output.dtype)
+            if use_transposed_state:
+                v_residual = v_t - torch.sum(state_head * k_t[:, :, None], dim=1)
+                v_residual = v_residual * beta_val.view(B, 1)
+                state_head = state_head + k_t[:, :, None] * v_residual[:, None, :]
+                head_out = torch.sum(state_head * q_t[:, :, None], dim=1).to(
+                    output.dtype
+                )
+            else:
+                v_residual = v_t - torch.sum(state_head * k_t[:, None, :], dim=2)
+                v_residual = v_residual * beta_val.view(B, 1)
+                state_head = state_head + v_residual[:, :, None] * k_t[:, None, :]
+                head_out = torch.sum(state_head * q_t[:, None, :], dim=2).to(
+                    output.dtype
+                )
             output[:, 0, head_idx] = torch.where(
                 valid_mask.view(B, 1), head_out, torch.zeros_like(head_out)
             )

--- a/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
+++ b/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
@@ -9,6 +9,7 @@
 
 import torch
 
+from vllm import _custom_ops as ops
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 
@@ -155,6 +156,31 @@ def _fused_sigmoid_gating_delta_rule_decode_gfx906(
     if b.ndim == 2:
         b = b.unsqueeze(0)
 
+    can_use_custom_op = (
+        A_log.dtype == a.dtype == b.dtype == dt_bias.dtype == q.dtype == k.dtype
+        == v.dtype
+        and initial_state.dtype in (q.dtype, torch.float32)
+    )
+    if can_use_custom_op:
+        try:
+            o = ops.fused_sigmoid_gating_delta_rule_gfx906_decode(
+                A_log=A_log,
+                a=a,
+                b=b,
+                dt_bias=dt_bias,
+                q=q,
+                k=k,
+                v=v,
+                state=initial_state,
+                beta=beta,
+                threshold=threshold,
+                scale=scale,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            )
+            return o, initial_state
+        except (AttributeError, RuntimeError):
+            pass
+
     head_ratio = HV // H
     q_head_idx = torch.arange(HV, device=q.device) // head_ratio
     q_t = q[0].index_select(1, q_head_idx).float()
@@ -183,6 +209,140 @@ def _fused_sigmoid_gating_delta_rule_decode_gfx906(
     o = torch.sum(state * q_t[:, :, None, :], dim=-1).unsqueeze(0).to(q.dtype)
 
     initial_state[:T].copy_(state.to(initial_state.dtype))
+    return o, initial_state
+
+
+def _fused_sigmoid_gating_delta_rule_indexed_decode_gfx906(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: float,
+    threshold: float,
+    scale: float,
+    initial_state: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if a.ndim == 2:
+        a = a.unsqueeze(0)
+    if b.ndim == 2:
+        b = b.unsqueeze(0)
+
+    can_use_custom_op = (
+        A_log.dtype == a.dtype == b.dtype == dt_bias.dtype == q.dtype == k.dtype
+        == v.dtype
+        and initial_state.dtype in (q.dtype, torch.float32)
+        and ssm_state_indices.dtype == torch.int32
+    )
+    if can_use_custom_op:
+        try:
+            o = ops.fused_sigmoid_gating_delta_rule_gfx906_indexed_decode(
+                A_log=A_log,
+                a=a,
+                b=b,
+                dt_bias=dt_bias,
+                q=q,
+                k=k,
+                v=v,
+                state=initial_state,
+                state_indices=ssm_state_indices,
+                beta=beta,
+                threshold=threshold,
+                scale=scale,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            )
+            return o, initial_state
+        except (AttributeError, RuntimeError):
+            pass
+
+    gathered_state = initial_state[ssm_state_indices].contiguous()
+    o, gathered_state = _fused_sigmoid_gating_delta_rule_decode_gfx906(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        threshold=threshold,
+        scale=scale,
+        initial_state=gathered_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
+    initial_state[ssm_state_indices] = gathered_state.to(initial_state.dtype)
+    return o, initial_state
+
+
+def fused_sigmoid_gating_delta_rule_update_kv_cache_gfx906(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: float,
+    threshold: float,
+    scale: float,
+    initial_state: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if a.ndim == 2:
+        a = a.unsqueeze(0)
+    if b.ndim == 2:
+        b = b.unsqueeze(0)
+
+    can_use_custom_op = (
+        A_log.dtype == a.dtype == b.dtype == dt_bias.dtype == q.dtype == k.dtype
+        == v.dtype
+        and initial_state.dtype in (q.dtype, torch.float32)
+        and ssm_state_indices.dtype == torch.int32
+    )
+    if can_use_custom_op:
+        try:
+            o = ops.fused_sigmoid_gating_delta_rule_gfx906_indexed_decode_kv_state(
+                A_log=A_log,
+                a=a,
+                b=b,
+                dt_bias=dt_bias,
+                q=q,
+                k=k,
+                v=v,
+                state=initial_state,
+                state_indices=ssm_state_indices,
+                beta=beta,
+                threshold=threshold,
+                scale=scale,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            )
+            return o, initial_state
+        except (AttributeError, RuntimeError):
+            pass
+
+    gathered_state = initial_state[ssm_state_indices].transpose(-1, -2).contiguous()
+    o, gathered_state = _fused_sigmoid_gating_delta_rule_decode_gfx906(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        threshold=threshold,
+        scale=scale,
+        initial_state=gathered_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )
+    initial_state[ssm_state_indices] = gathered_state.transpose(-1, -2).to(
+        initial_state.dtype
+    )
     return o, initial_state
 
 
@@ -368,11 +528,44 @@ def fused_sigmoid_gating_delta_rule_update(
             and q.shape[0] == 1
             and initial_state is not None
             and inplace_final_state
-            and ssm_state_indices is None
             and num_accepted_tokens is None
-            and q.shape[1] == initial_state.shape[0]
         )
         if decode_gfx906_path:
+            if ssm_state_indices is not None:
+                return _fused_sigmoid_gating_delta_rule_indexed_decode_gfx906(
+                    A_log=A_log,
+                    a=a,
+                    b=b,
+                    dt_bias=dt_bias,
+                    q=q,
+                    k=k,
+                    v=v,
+                    beta=beta,
+                    threshold=threshold,
+                    scale=scale,
+                    initial_state=initial_state,
+                    ssm_state_indices=ssm_state_indices,
+                    use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+                )
+            if q.shape[1] != initial_state.shape[0]:
+                return _fused_sigmoid_gating_delta_rule_update_gfx906_eager(
+                    A_log=A_log,
+                    a=a,
+                    b=b,
+                    dt_bias=dt_bias,
+                    q=q,
+                    k=k,
+                    v=v,
+                    beta=beta,
+                    threshold=threshold,
+                    scale=scale,
+                    initial_state=initial_state,
+                    inplace_final_state=inplace_final_state,
+                    cu_seqlens=cu_seqlens,
+                    ssm_state_indices=ssm_state_indices,
+                    num_accepted_tokens=num_accepted_tokens,
+                    use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+                )
             return _fused_sigmoid_gating_delta_rule_decode_gfx906(
                 A_log=A_log,
                 a=a,

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -305,6 +305,32 @@ class GemmaRMSNorm(CustomOp):
         """PyTorch-native implementation equivalent to forward()."""
         return self.forward_static(self.weight.data, self.variance_epsilon, x, residual)
 
+    @staticmethod
+    def _use_gfx906_kernel(x: torch.Tensor, weight: torch.Tensor,
+                           residual: torch.Tensor | None) -> bool:
+        if not current_platform.is_rocm() or not x.is_cuda:
+            return False
+        try:
+            from vllm.platforms.rocm import on_gfx906
+        except ImportError:
+            return False
+        if not on_gfx906():
+            return False
+        if x.dtype not in (torch.float16, torch.float32):
+            return False
+        if weight.dtype != x.dtype or weight.device != x.device:
+            return False
+        if x.ndim < 2 or x.shape[-1] != weight.numel():
+            return False
+        if residual is None:
+            return True
+        return (
+            residual.is_cuda
+            and residual.device == x.device
+            and residual.shape == x.shape
+            and residual.dtype in (x.dtype, torch.float32)
+        )
+
     def forward_cuda(
         self,
         x: torch.Tensor,
@@ -313,14 +339,21 @@ class GemmaRMSNorm(CustomOp):
         if torch.compiler.is_compiling():
             return self.forward_native(x, residual)
 
-        capability = current_platform.get_device_capability()
-        if (
-            current_platform.is_rocm()
-            and capability is not None
-            and capability.major == 9
-            and capability.minor == 0
-        ):
-            return self.forward_native(x, residual)
+        if self._use_gfx906_kernel(x, self.weight.data, residual):
+            from vllm import _custom_ops as ops
+
+            if residual is None:
+                return ops.gemma_rms_norm_gfx906(
+                    x,
+                    self.weight.data,
+                    self.variance_epsilon,
+                )
+            return ops.gemma_fused_add_rms_norm_gfx906(
+                x,
+                residual,
+                self.weight.data,
+                self.variance_epsilon,
+            )
 
         if not getattr(self, "_is_compiled", False):
             self.forward_static = torch.compile(  # type: ignore
@@ -427,6 +460,30 @@ class RMSNormGated(CustomOp):
     def forward_cuda(
         self, x: torch.Tensor, z: torch.Tensor | None = None
     ) -> torch.Tensor:
+        if (
+            self._use_native_rocm_gfx90
+            and z is not None
+            and self.group_size is None
+            and x.dim() == 2
+            and z.dim() == 2
+            and x.is_cuda
+            and z.is_cuda
+            and x.dtype == z.dtype == self.weight.dtype
+        ):
+            from vllm import _custom_ops as ops
+
+            if x.stride(-1) != 1:
+                x = x.contiguous()
+            if z.stride(-1) != 1:
+                z = z.contiguous()
+            return ops.rms_norm_gated_gfx906(
+                x,
+                self.weight,
+                z,
+                self.eps,
+                self.norm_before_gate,
+            )
+
         if torch.compiler.is_compiling() or self._use_native_rocm_gfx90:
             return self.forward_native(x, z)
 

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -62,6 +62,10 @@ from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 logger = init_logger(__name__)
 
 
+def _gdn_runtime_debug_enabled() -> bool:
+    return bool(os.environ.get("VLLM_QWEN35_RUNTIME_DEBUG_FILE"))
+
+
 def _append_gdn_runtime_debug(message: str) -> None:
     debug_file = os.environ.get("VLLM_QWEN35_RUNTIME_DEBUG_FILE")
     if not debug_file:
@@ -626,17 +630,18 @@ class GatedDeltaNetAttention(nn.Module, MambaBase):
                 f"qtype_shards={getattr(qtype, 'shard_weight_type', None)}"
             )
 
-        _append_gdn_runtime_debug(
-            "PROJMETA "
-            + " | ".join(
-                [
-                    f"prefix={self.prefix}",
-                    summarize_proj("in_proj_qkv", getattr(self, "in_proj_qkv", None)),
-                    summarize_proj("in_proj_z", getattr(self, "in_proj_z", None)),
-                    summarize_proj("in_proj_ba", getattr(self, "in_proj_ba", None)),
-                ]
+        if _gdn_runtime_debug_enabled():
+            _append_gdn_runtime_debug(
+                "PROJMETA "
+                + " | ".join(
+                    [
+                        f"prefix={self.prefix}",
+                        summarize_proj("in_proj_qkv", getattr(self, "in_proj_qkv", None)),
+                        summarize_proj("in_proj_z", getattr(self, "in_proj_z", None)),
+                        summarize_proj("in_proj_ba", getattr(self, "in_proj_ba", None)),
+                    ]
+                )
             )
-        )
 
     def _forward_core(self, mixed_qkv: torch.Tensor, b: torch.Tensor, a: torch.Tensor, core_attn_out: torch.Tensor):
         self._log_projection_debug_once()
@@ -651,16 +656,16 @@ class GatedDeltaNetAttention(nn.Module, MambaBase):
         attn_metadata = attn_metadata[self.prefix]
         assert isinstance(attn_metadata, GDNAttentionMetadata)
 
-        _append_gdn_runtime_debug(
-            "COREMETA "
-            f"prefix={self.prefix} packed={self.enable_packed_recurrent_decode} "
-            f"spec_is_none={attn_metadata.spec_sequence_masks is None} "
-            f"num_prefills={attn_metadata.num_prefills} num_decodes={attn_metadata.num_decodes}"
-        )
+        if _gdn_runtime_debug_enabled():
+            _append_gdn_runtime_debug(
+                "COREMETA "
+                f"prefix={self.prefix} packed={self.enable_packed_recurrent_decode} "
+                f"spec_is_none={attn_metadata.spec_sequence_masks is None} "
+                f"num_prefills={attn_metadata.num_prefills} num_decodes={attn_metadata.num_decodes}"
+            )
 
         if (
             self.enable_packed_recurrent_decode
-            and not _is_gfx906_rocm()
             and attn_metadata.spec_sequence_masks is None
             and attn_metadata.num_prefills == 0
             and attn_metadata.num_decodes > 0
@@ -751,7 +756,13 @@ class GatedDeltaNetAttention(nn.Module, MambaBase):
         query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
         query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(mixed_qkv_non_spec)
 
-        if attn_metadata.num_prefills > 0 or attn_metadata.num_decodes > 0:
+        g_non_spec: torch.Tensor | None = None
+        beta_non_spec: torch.Tensor | None = None
+
+        def ensure_non_spec_gating() -> None:
+            nonlocal g_non_spec, beta_non_spec
+            if g_non_spec is not None:
+                return
             g, beta = fused_gdn_gating(self.A_log, a, b, self.dt_bias)
             if spec_sequence_masks is not None:
                 g_non_spec = g.index_select(1, non_spec_token_indx)
@@ -759,9 +770,6 @@ class GatedDeltaNetAttention(nn.Module, MambaBase):
             else:
                 g_non_spec = g
                 beta_non_spec = beta
-        else:
-            g_non_spec = None
-            beta_non_spec = None
 
         if spec_sequence_masks is not None:
             core_attn_out_spec, last_recurrent_state = fused_sigmoid_gating_delta_rule_update(
@@ -793,11 +801,12 @@ class GatedDeltaNetAttention(nn.Module, MambaBase):
                 initial_state = ssm_state[non_spec_state_indices_tensor].transpose(-1, -2).contiguous()
                 if has_initial_state is not None:
                     initial_state[~has_initial_state, ...] = 0
-                _append_gdn_runtime_debug(
-                    "PREFILL "
-                    f"q={tuple(query_non_spec.shape)} k={tuple(key_non_spec.shape)} "
-                    f"v={tuple(value_non_spec.shape)} a={tuple(a_non_spec.shape)} b={tuple(b_non_spec.shape)}"
-                )
+                if _gdn_runtime_debug_enabled():
+                    _append_gdn_runtime_debug(
+                        "PREFILL "
+                        f"q={tuple(query_non_spec.shape)} k={tuple(key_non_spec.shape)} "
+                        f"v={tuple(value_non_spec.shape)} a={tuple(a_non_spec.shape)} b={tuple(b_non_spec.shape)}"
+                    )
                 core_attn_out_non_spec, last_recurrent_state = fused_sigmoid_gating_delta_rule_update(
                     A_log=self.A_log,
                     a=a_non_spec,
@@ -816,14 +825,18 @@ class GatedDeltaNetAttention(nn.Module, MambaBase):
                     -1, -2
                 ).to(ssm_state.dtype)
             else:
+                ensure_non_spec_gating()
+                assert g_non_spec is not None
+                assert beta_non_spec is not None
                 initial_state = ssm_state.contiguous()
                 if has_initial_state is not None:
                     initial_state[non_spec_state_indices_tensor[~has_initial_state], ...] = 0
-                _append_gdn_runtime_debug(
-                    "PREFILL "
-                    f"q={tuple(query_non_spec.shape)} k={tuple(key_non_spec.shape)} "
-                    f"v={tuple(value_non_spec.shape)} g={tuple(g_non_spec.shape)} beta={tuple(beta_non_spec.shape)}"
-                )
+                if _gdn_runtime_debug_enabled():
+                    _append_gdn_runtime_debug(
+                        "PREFILL "
+                        f"q={tuple(query_non_spec.shape)} k={tuple(key_non_spec.shape)} "
+                        f"v={tuple(value_non_spec.shape)} g={tuple(g_non_spec.shape)} beta={tuple(beta_non_spec.shape)}"
+                    )
                 core_attn_out_non_spec, last_recurrent_state = self.chunk_gated_delta_rule(
                     q=query_non_spec.transpose(1, 2),
                     k=key_non_spec.transpose(1, 2),
@@ -839,7 +852,6 @@ class GatedDeltaNetAttention(nn.Module, MambaBase):
                 ssm_state.copy_(last_recurrent_state.to(ssm_state.dtype))
         elif attn_metadata.num_decodes > 0:
             if _is_gfx906_rocm():
-                initial_state = ssm_state[non_spec_state_indices_tensor].transpose(-1, -2).contiguous()
                 core_attn_out_non_spec, last_recurrent_state = fused_sigmoid_gating_delta_rule_update(
                     A_log=self.A_log,
                     a=a,
@@ -848,15 +860,12 @@ class GatedDeltaNetAttention(nn.Module, MambaBase):
                     q=query_non_spec,
                     k=key_non_spec,
                     v=value_non_spec,
-                    initial_state=initial_state,
+                    initial_state=ssm_state,
                     inplace_final_state=True,
                     cu_seqlens=non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
-                    ssm_state_indices=None,
+                    ssm_state_indices=non_spec_state_indices_tensor,
                     use_qk_l2norm_in_kernel=True,
                 )
-                ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.transpose(
-                    -1, -2
-                ).to(ssm_state.dtype)
             else:
                 core_attn_out_non_spec, last_recurrent_state = fused_sigmoid_gating_delta_rule_update(
                     A_log=self.A_log,
@@ -922,11 +931,12 @@ class GatedDeltaNetAttention(nn.Module, MambaBase):
         )
 
         out_buf = core_attn_out[:num_actual_tokens].unsqueeze(1)
-        _append_gdn_runtime_debug(
-            "DECODE_PACKED "
-            f"mixed_qkv={tuple(mixed_qkv_non_spec.shape)} a={tuple(a.shape)} b={tuple(b.shape)} "
-            f"out={tuple(out_buf.shape)}"
-        )
+        if _gdn_runtime_debug_enabled():
+            _append_gdn_runtime_debug(
+                "DECODE_PACKED "
+                f"mixed_qkv={tuple(mixed_qkv_non_spec.shape)} a={tuple(a.shape)} b={tuple(b.shape)} "
+                f"out={tuple(out_buf.shape)}"
+            )
         fused_recurrent_gated_delta_rule_packed_decode(
             mixed_qkv=mixed_qkv_non_spec,
             a=a,

--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -4,11 +4,11 @@
 # Copyright (c) 2024, Tri Dao.
 # Adapted from https://github.com/Dao-AILab/causal-conv1d/blob/main/causal_conv1d/causal_conv1d_interface.py
 
-
 import numpy as np
 import torch
 import torch.nn.functional as F
 
+from vllm import _custom_ops as ops
 import vllm.envs as envs
 from vllm.attention.backends.utils import PAD_SLOT_ID
 from vllm.platforms import current_platform
@@ -136,6 +136,28 @@ def _causal_conv1d_gfx906_decode_update_fallback(
     activation: str | None,
     pad_slot_id: int,
 ) -> torch.Tensor:
+    use_custom_op = (
+        x.dtype == weight.dtype
+        and conv_states.dtype in (x.dtype, torch.float32)
+        and (bias is None or bias.dtype == x.dtype)
+        and (x.dim() == 2 or (x.dim() == 3 and x.shape[-1] == 1))
+    )
+    if use_custom_op:
+        try:
+            x_for_op = x.squeeze(-1) if x.dim() == 3 else x
+            out = ops.causal_conv1d_gfx906_decode_update(
+                x=x_for_op,
+                conv_state=conv_states,
+                weight=weight,
+                bias=bias,
+                conv_state_indices=conv_state_indices,
+                pad_slot_id=pad_slot_id,
+                silu_activation=activation in ["silu", "swish"],
+            )
+            return out.unsqueeze(-1) if x.dim() == 3 else out
+        except (AttributeError, RuntimeError):
+            pass
+
     original_x_dtype = x.dtype
     x = x.to(conv_states.dtype)
     unsqueeze = x.dim() == 2

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -13,7 +13,6 @@ from torch.nn.parameter import Parameter, UninitializedParameter
 
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
-from vllm.platforms.rocm import on_gfx906
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
     FusedMoEQuantConfig,
@@ -233,6 +232,142 @@ except AttributeError as error:
     raise error
 
 
+def _mmvq_safe_batch(qweight: torch.Tensor, qweight_type: int) -> int:
+    if qweight_type in IMATRIX_QUANT_TYPES:
+        return 8 if qweight.shape[0] > 5120 else 16
+    return 2 if qweight.shape[0] > 5120 else 6
+
+
+def _can_share_mmvq_activation(
+    x: torch.Tensor,
+    qweights: list[torch.Tensor],
+    qweight_types: list[int],
+) -> bool:
+    if x.shape[0] == 0:
+        return False
+    for qweight, qweight_type in zip(qweights, qweight_types):
+        if qweight_type not in MMVQ_QUANT_TYPES:
+            return False
+        if x.shape[0] > _mmvq_safe_batch(qweight, qweight_type):
+            return False
+    return True
+
+
+def _shared_mmvq_max_batch(
+    qweights: list[torch.Tensor],
+    qweight_types: list[int],
+) -> int:
+    max_batch = torch.iinfo(torch.int32).max
+    for qweight, qweight_type in zip(qweights, qweight_types):
+        if qweight_type not in MMVQ_QUANT_TYPES:
+            return 0
+        max_batch = min(max_batch, _mmvq_safe_batch(qweight, qweight_type))
+    return max_batch
+
+
+def _get_full_mmvq_shard_weight(
+    layer: torch.nn.Module,
+    qweight_types: list[int],
+) -> tuple[torch.Tensor, int] | None:
+    qweight = layer.qweight
+    shard_id = getattr(qweight, "shard_id", [])
+    shard_offset_map = getattr(qweight, "shard_offset_map", None)
+    if not shard_id or not shard_offset_map:
+        return None
+    if len(set(qweight_types)) != 1:
+        return None
+
+    qweight_type = qweight_types[0]
+    if qweight_type not in MMVQ_QUANT_TYPES:
+        return None
+
+    expected_start = 0
+    packed_width = qweight.shape[1]
+    for idx in _ordered_gguf_shard_ids(shard_id):
+        start, end, offset = shard_offset_map[idx]
+        if start != expected_start or offset != packed_width:
+            return None
+        expected_start = end
+
+    if expected_start != qweight.shape[0]:
+        return None
+    return qweight, qweight_type
+
+
+def _collect_gguf_linear_shards(
+    layer: torch.nn.Module,
+) -> tuple[list[torch.Tensor], list[int]] | None:
+    cached = getattr(layer, "_gguf_collected_shards", None)
+    if cached is not None:
+        return cached
+
+    if not hasattr(layer, "qweight") or not hasattr(layer, "qweight_type"):
+        return None
+    if getattr(layer, "use_dense_gguf_fallback", False):
+        return None
+    if not _has_loaded_gguf_weight(layer):
+        return None
+
+    shard_id = getattr(layer.qweight, "shard_id", [])
+    if shard_id:
+        if all(isinstance(idx, int) for idx in shard_id):
+            shard_id = sorted(shard_id)
+        elif {"q", "k", "v"}.issubset(set(shard_id)):
+            shard_id = ["q", "k", "v"]
+        qweight = layer.qweight
+        qweights = []
+        qweight_types = []
+        for idx in shard_id:
+            qweight_type = layer.qweight_type.shard_weight_type[idx]
+            if hasattr(layer.qweight, "shard_offset_map"):
+                start, end, offset = layer.qweight.shard_offset_map[idx]
+                shard = getattr(layer, "_gguf_shard_cache", {}).get(idx)
+                if shard is None:
+                    shard = qweight[start:end, :offset]
+                    if not shard.is_contiguous():
+                        shard = shard.contiguous()
+            else:
+                shard = qweight.data_container[qweight.shard_id_map[idx]].contiguous()
+            qweights.append(shard)
+            qweight_types.append(qweight_type)
+        return qweights, qweight_types
+
+    return [layer.qweight], [layer.qweight_type.weight_type]
+
+
+def _fused_mul_mat_gguf_sharded_mmvq(
+    x: torch.Tensor,
+    qweights: list[torch.Tensor],
+    qweight_types: list[int],
+) -> torch.Tensor:
+    return ops.ggml_mul_mat_vec_a8_sharded(qweights, x, qweight_types)
+
+
+def _fused_mul_mat_gguf_sharded_mmvq_fake(
+    x: torch.Tensor,
+    qweights: list[torch.Tensor],
+    qweight_types: list[int],
+) -> torch.Tensor:
+    return torch.empty(
+        x.shape[0],
+        sum(qweight.shape[0] for qweight in qweights),
+        dtype=x.dtype,
+        device=x.device,
+    )
+
+
+try:
+    direct_register_custom_op(
+        op_name="_fused_mul_mat_gguf_sharded_mmvq",
+        op_func=_fused_mul_mat_gguf_sharded_mmvq,
+        fake_impl=_fused_mul_mat_gguf_sharded_mmvq_fake,
+    )
+    fused_mul_mat_gguf_sharded_mmvq = torch.ops.vllm._fused_mul_mat_gguf_sharded_mmvq
+
+except AttributeError as error:
+    raise error
+
+
 def _fused_moe_gguf(
     x: torch.Tensor,
     w1: torch.Tensor,
@@ -422,26 +557,16 @@ def _dequantize_gguf_weight(
     if qweight_type in DEQUANT_TYPES:
         block_size, type_size = gguf.GGML_QUANT_SIZES[qweight_type]
         shape = (qweight.shape[0], qweight.shape[1] // type_size * block_size)
-        return ops.ggml_dequantize(qweight, qweight_type, *shape, out_dtype).contiguous()
+        return ops.ggml_dequantize(
+            qweight, qweight_type, *shape, out_dtype
+        ).contiguous()
 
     qweight_type = WeightType(qweight_type)
     raise NotImplementedError(f"Unsupported GGUF quantization type: {qweight_type}")
 
 
 def _is_gfx906_qwen35_linear_attn_fallback(layer: torch.nn.Module) -> bool:
-    if not on_gfx906():
-        return False
-    prefix = getattr(layer, "prefix", "")
-    if ".linear_attn." not in prefix:
-        return False
-    return prefix.endswith((
-        ".linear_attn.in_proj_qkvz",
-        ".linear_attn.in_proj_qkv",
-        ".linear_attn.in_proj_z",
-        ".linear_attn.in_proj_ba",
-        ".linear_attn.in_proj_b",
-        ".linear_attn.in_proj_a",
-    ))
+    return False
 
 
 def _ordered_gguf_shard_ids(shard_id: list[int | str]) -> list[int | str]:
@@ -476,6 +601,13 @@ def _materialize_dense_gguf_weight(
             out_dtype,
         )
     return Parameter(weight, requires_grad=False)
+
+
+def _has_loaded_gguf_weight(layer: torch.nn.Module) -> bool:
+    qweight = layer.qweight
+    if getattr(qweight, "shard_id", None):
+        return True
+    return not isinstance(qweight, UninitializedParameter)
 
 
 class GGUFLinearMethod(LinearMethodBase):
@@ -541,7 +673,9 @@ class GGUFLinearMethod(LinearMethodBase):
             raise ValueError(
                 f"Unsupported GGUF quantization type {qweight_type} in layer {layer}."
             )
-        if _is_gfx906_qwen35_linear_attn_fallback(layer):
+        if _is_gfx906_qwen35_linear_attn_fallback(layer) and _has_loaded_gguf_weight(
+            layer
+        ):
             layer.register_parameter(
                 "weight",
                 _materialize_dense_gguf_weight(layer, self.params_dtype),
@@ -553,6 +687,8 @@ class GGUFLinearMethod(LinearMethodBase):
         # For MergedColumnParallelLinear and QKVParallelLinear, we need to
         # materialize the padded weight parameter for CUDA Graph compatibility.
         self._create_padded_weight_param(layer)
+        self._cache_gguf_shards(layer)
+        self._cache_gguf_shard_metadata(layer)
 
     def _create_padded_weight_param(self, layer: torch.nn.Module):
         """Create padded weight parameter for GGUF MergedLinear layer."""
@@ -567,11 +703,7 @@ class GGUFLinearMethod(LinearMethodBase):
             set_weight_attrs(padded_param, vars(qweight))
             set_weight_attrs(
                 padded_param,
-                {
-                    "shard_offset_map": {
-                        shard_id[0]: (0, data.size(0), data.size(1))
-                    }
-                },
+                {"shard_offset_map": {shard_id[0]: (0, data.size(0), data.size(1))}},
             )
             layer.register_parameter("qweight", padded_param)
         elif len(data_container) > 1:
@@ -603,6 +735,40 @@ class GGUFLinearMethod(LinearMethodBase):
             set_weight_attrs(padded_param, {"shard_offset_map": shard_offset_map})
             layer.register_parameter("qweight", padded_param)
 
+    def _cache_gguf_shards(self, layer: torch.nn.Module):
+        qweight = layer.qweight
+        shard_offset_map = getattr(qweight, "shard_offset_map", None)
+        if not shard_offset_map:
+            return
+
+        cache = {}
+        for idx, (start, end, offset) in shard_offset_map.items():
+            shard = qweight[start:end, :offset]
+            if not shard.is_contiguous():
+                shard = shard.contiguous()
+            cache[idx] = shard
+        layer._gguf_shard_cache = cache
+
+    def _cache_gguf_shard_metadata(self, layer: torch.nn.Module):
+        if not getattr(layer.qweight, "shard_id", []):
+            return
+        collected = _collect_gguf_linear_shards(layer)
+        if collected is None:
+            return
+        qweights, qweight_types = collected
+        layer._gguf_collected_shards = collected
+        layer._gguf_sharded_mmvq_max_batch = _shared_mmvq_max_batch(
+            qweights, qweight_types
+        )
+        full_mmvq = _get_full_mmvq_shard_weight(layer, qweight_types)
+        if full_mmvq is not None:
+            qweight, qweight_type = full_mmvq
+            layer._gguf_full_shard_mmvq = (
+                qweight,
+                qweight_type,
+                _mmvq_safe_batch(qweight, qweight_type),
+            )
+
     def apply(
         self,
         layer: torch.nn.Module,
@@ -616,27 +782,33 @@ class GGUFLinearMethod(LinearMethodBase):
                 out.add_(bias.to(dtype=out.dtype))
             return out
 
-        shard_id = layer.qweight.shard_id
+        shard_id = getattr(layer.qweight, "shard_id", [])
 
         if shard_id:
-            # dequantize shard weights respectively
-            if all(isinstance(idx, int) for idx in shard_id):
-                shard_id = sorted(shard_id)
-            elif {"q", "k", "v"}.issubset(set(shard_id)):
-                shard_id = ["q", "k", "v"]
-            qweight = layer.qweight
-            result = []
-            for idx in shard_id:
-                qweight_type = layer.qweight_type.shard_weight_type[idx]
-                if hasattr(layer.qweight, "shard_offset_map"):
-                    start, end, offset = layer.qweight.shard_offset_map[idx]
-                    shard = qweight[start:end, :offset].contiguous()
+            collected = _collect_gguf_linear_shards(layer)
+            assert collected is not None
+            qweights, qweight_types = collected
+            mmvq_max_batch = getattr(layer, "_gguf_sharded_mmvq_max_batch", None)
+            can_share_mmvq = (
+                x.shape[0] > 0
+                and mmvq_max_batch is not None
+                and x.shape[0] <= mmvq_max_batch
+            )
+            if mmvq_max_batch is None:
+                can_share_mmvq = _can_share_mmvq_activation(x, qweights, qweight_types)
+            if can_share_mmvq:
+                full_mmvq = getattr(layer, "_gguf_full_shard_mmvq", None)
+                if full_mmvq is not None and x.shape[0] <= full_mmvq[2]:
+                    qweight, qweight_type, _ = full_mmvq
+                    out = fused_mul_mat_gguf(x, qweight, qweight_type)
                 else:
-                    shard = qweight.data_container[qweight.shard_id_map[idx]].contiguous()
-                result.append(
+                    out = fused_mul_mat_gguf_sharded_mmvq(x, qweights, qweight_types)
+            else:
+                result = [
                     fused_mul_mat_gguf(x, shard, qweight_type)
-                )
-            out = torch.cat(result, axis=1)
+                    for shard, qweight_type in zip(qweights, qweight_types)
+                ]
+                out = torch.cat(result, axis=1)
         else:
             qweight = layer.qweight
             qweight_type = layer.qweight_type.weight_type

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -241,6 +241,26 @@ class GGUFModelLoader(BaseModelLoader):
                         r"model\.layers\.(?P<bid>\d+)\.linear_attn\.dt_bias", hf_name
                     ):
                         return f"blk.{m['bid']}.ssm_dt.bias"
+                    if m := re.fullmatch(
+                        r"model\.layers\.(?P<bid>\d+)\.linear_attn\.in_proj_qkv",
+                        base_name,
+                    ):
+                        return f"blk.{m['bid']}.attn_qkv.{suffix}"
+                    if m := re.fullmatch(
+                        r"model\.layers\.(?P<bid>\d+)\.linear_attn\.in_proj_z",
+                        base_name,
+                    ):
+                        return f"blk.{m['bid']}.attn_gate.{suffix}"
+                    if m := re.fullmatch(
+                        r"model\.layers\.(?P<bid>\d+)\.linear_attn\.in_proj_b",
+                        base_name,
+                    ):
+                        return f"blk.{m['bid']}.ssm_beta.{suffix}"
+                    if m := re.fullmatch(
+                        r"model\.layers\.(?P<bid>\d+)\.linear_attn\.in_proj_a",
+                        base_name,
+                    ):
+                        return f"blk.{m['bid']}.ssm_alpha.{suffix}"
                 return None
 
             if suffix:
@@ -266,6 +286,30 @@ class GGUFModelLoader(BaseModelLoader):
             elif hf_name not in gguf_to_hf_name_map.values():
                 # Parameter not in manual overrides either
                 unmapped_params.append(hf_name)
+
+        if model_type == "qwen35" and vllm_arch in (
+            "Qwen3_5ForCausalLM",
+            "Qwen3_5ForConditionalGeneration",
+        ):
+            for idx in range(text_num_layers):
+                if text_config.layer_types[idx] != "linear_attention":
+                    continue
+                gguf_to_hf_name_map[f"blk.{idx}.attn_qkv.weight"] = (
+                    "language_model."
+                    f"model.layers.{idx}.linear_attn.in_proj_qkv.weight"
+                )
+                gguf_to_hf_name_map[f"blk.{idx}.attn_gate.weight"] = (
+                    "language_model."
+                    f"model.layers.{idx}.linear_attn.in_proj_z.weight"
+                )
+                gguf_to_hf_name_map[f"blk.{idx}.ssm_beta.weight"] = (
+                    "language_model."
+                    f"model.layers.{idx}.linear_attn.in_proj_b.weight"
+                )
+                gguf_to_hf_name_map[f"blk.{idx}.ssm_alpha.weight"] = (
+                    "language_model."
+                    f"model.layers.{idx}.linear_attn.in_proj_a.weight"
+                )
 
         # All parameters must be mapped: both vision/projector and backbone
         if unmapped_params:

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -25,7 +25,6 @@
 """Inference-only Qwen3.5 Series compatible with HuggingFace weights."""
 
 import os
-import os
 import typing
 from collections.abc import Callable, Iterable
 from inspect import signature
@@ -47,7 +46,10 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import (
     GemmaRMSNorm as Qwen3_5RMSNorm,
 )
-from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+)
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.mamba.gdn_linear_attn import GatedDeltaNetAttention
 from vllm.model_executor.layers.mamba.mamba_utils import (
@@ -128,6 +130,24 @@ def _append_qwen35_load_debug(message: str) -> None:
         pass
 
 
+def _is_qwen35_gguf_projection_aux_param(name: str) -> bool:
+    if ".linear_attn.in_proj_" not in name:
+        return False
+    if not name.endswith((".qweight", ".qweight_type")):
+        return False
+    return any(
+        f".{proj}." in name
+        for proj in (
+            "in_proj_qkvz",
+            "in_proj_qkv",
+            "in_proj_z",
+            "in_proj_ba",
+            "in_proj_b",
+            "in_proj_a",
+        )
+    )
+
+
 class Qwen3_5ProcessingInfo(Qwen3VLProcessingInfo):
     def get_hf_config(self):
         return self.ctx.get_hf_config(Qwen3_5Config)
@@ -167,8 +187,16 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
         self.expand_qk_heads_for_gdn = _env_bool(
             "VLLM_QWEN35_EXPAND_QK", True
         )
+        capability = current_platform.get_device_capability()
+        default_recurrent_prefill = not (
+            self.split_projections
+            and current_platform.is_rocm()
+            and capability is not None
+            and capability.major == 9
+            and capability.minor == 0
+        )
         self.use_recurrent_prefill_for_gdn = _env_bool(
-            "VLLM_QWEN35_REC_PREFILL", True
+            "VLLM_QWEN35_REC_PREFILL", default_recurrent_prefill
         )
         self.use_local_recurrent_decode_for_gdn = _env_bool(
             "VLLM_QWEN35_LOCAL_REC_DECODE", False
@@ -176,27 +204,38 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
         self.use_qk_l2norm_in_kernel_for_gdn = _env_bool(
             "VLLM_QWEN35_QK_L2NORM", True
         )
-        if prefix.endswith("layers.0.linear_attn"):
-            logger.warning(
-                "[qwen3.5 init] prefix=%s split_projections=%s", prefix, self.split_projections
-            )
-            debug_file = os.getenv("VLLM_QWEN35_INIT_DEBUG_FILE")
-            if debug_file:
-                try:
-                    with open(debug_file, "a", encoding="utf-8") as f:
-                        f.write(
-                            f"prefix={prefix} split_projections={self.split_projections} modules={list(self._modules.keys())}\n"
-                        )
-                except Exception:
-                    pass
+        self.use_transposed_state_for_packed_decode = self.split_projections
         if self.split_projections:
-            self.in_proj_qkvz.output_sizes = [
-                self.key_dim,
-                self.key_dim,
-                self.value_dim,
-                self.value_dim,
-            ]
-            self.in_proj_ba.output_sizes = [self.num_v_heads, self.num_v_heads]
+            del self.in_proj_qkvz
+            del self.in_proj_ba
+            self.in_proj_qkv = MergedColumnParallelLinear(
+                input_size=self.hidden_size,
+                output_sizes=[self.key_dim, self.key_dim, self.value_dim],
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.in_proj_qkv",
+            )
+            self.in_proj_z = ColumnParallelLinear(
+                input_size=self.hidden_size,
+                output_size=self.value_dim,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.in_proj_z",
+            )
+            self.in_proj_b = ColumnParallelLinear(
+                input_size=self.hidden_size,
+                output_size=self.num_v_heads,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.in_proj_b",
+            )
+            self.in_proj_a = ColumnParallelLinear(
+                input_size=self.hidden_size,
+                output_size=self.num_v_heads,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.in_proj_a",
+            )
         else:
             self.in_proj_qkvz.output_sizes = [
                 self.key_dim,
@@ -229,17 +268,31 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
         if head_ratio <= 1:
             return query.contiguous(), key.contiguous()
 
-        if (
-            self.split_projections
-            and self.quant_config is not None
-            and self.quant_config.get_name() == "gguf"
-        ):
+        tiled_qk_expand = os.getenv(
+            "VLLM_QWEN35_TILED_QK_EXPAND",
+            "1" if self.split_projections else "0",
+        )
+        if tiled_qk_expand.lower() in {"1", "true", "yes", "on"}:
             query = query.repeat(1, 1, head_ratio, 1)
             key = key.repeat(1, 1, head_ratio, 1)
         else:
             query = query.repeat_interleave(head_ratio, dim=2)
             key = key.repeat_interleave(head_ratio, dim=2)
         return query.contiguous(), key.contiguous()
+
+    def _use_gfx906_packed_decode_path(self) -> bool:
+        raw = os.getenv(
+            "VLLM_QWEN35_PACKED_DECODE",
+            "1" if self.split_projections else "0",
+        )
+        return raw.lower() in {"1", "true", "yes", "on"}
+
+    def _use_tiled_qk_head_mapping_for_packed_decode(self) -> bool:
+        raw = os.getenv(
+            "VLLM_QWEN35_PACKED_DECODE_TILED_QK",
+            "1" if self.split_projections else "0",
+        )
+        return raw.lower() in {"1", "true", "yes", "on"}
 
     def _maybe_log_debug_stats(self, **tensors: torch.Tensor) -> None:
         if os.getenv("VLLM_QWEN35_GGUF_DEBUG", "0") != "1":
@@ -330,21 +383,22 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
         num_tokens = hidden_states.size(0)
 
         if self.split_projections:
-            projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
-            projected_states_ba, _ = self.in_proj_ba(hidden_states)
+            projected_states_qkv, _ = self.in_proj_qkv(hidden_states)
+            z, _ = self.in_proj_z(hidden_states)
+            b, _ = self.in_proj_b(hidden_states)
+            a, _ = self.in_proj_a(hidden_states)
 
             q_size = self.key_dim // self.tp_size
             k_size = self.key_dim // self.tp_size
             v_size = self.value_dim // self.tp_size
-            q, k, v, z = torch.split(
-                projected_states_qkvz,
-                [q_size, k_size, v_size, v_size],
+            q, k, v = torch.split(
+                projected_states_qkv,
+                [q_size, k_size, v_size],
                 dim=-1,
             )
 
-            mixed_qkv = torch.cat((q, k, v), dim=-1)
+            mixed_qkv = projected_states_qkv
             z = z.reshape(z.size(0), -1, self.head_v_dim)
-            b, a = projected_states_ba.chunk(2, dim=-1)
             b = b.contiguous()
             a = a.contiguous()
         else:
@@ -398,9 +452,16 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
 
     def _use_gfx906_chunk_decode_path(self) -> bool:
         raw = os.getenv("VLLM_QWEN35_CHUNK_DECODE")
-        if raw is None:
-            return False
-        return raw.lower() in {"1", "true", "yes", "on"}
+        if raw is not None:
+            return raw.lower() in {"1", "true", "yes", "on"}
+        capability = current_platform.get_device_capability()
+        return (
+            self.split_projections
+            and current_platform.is_rocm()
+            and capability is not None
+            and capability.major == 9
+            and capability.minor == 0
+        )
 
 
 class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
@@ -639,7 +700,7 @@ class Qwen3_5Model(Qwen3NextModel):
             f"MODE force_split={force_split} has_split_qkv={has_split_qkv} has_split_ba={has_split_ba} has_fused_ba={has_fused_ba}"
         )
 
-        if has_fused_ba and not has_split_ba:
+        if has_fused_ba and not has_split_ba and not force_split:
             reverse_ba = os.getenv("VLLM_QWEN35_REVERSE_BA_SHARDS", "0").lower() in {
                 "1",
                 "true",
@@ -661,7 +722,7 @@ class Qwen3_5Model(Qwen3NextModel):
                     ]
                 )
 
-        if not has_split_qkv:
+        if not has_split_qkv and not force_split:
             stacked_params_mapping.extend(
                 [
                     ("in_proj_qkvz", "in_proj_qkv", (0, 1, 2)),
@@ -821,7 +882,7 @@ class Qwen3_5Model(Qwen3NextModel):
                     is_fused_expert = True
                     expert_params_mapping = fused_expert_params_mapping
 
-                if weight_name not in name:
+                if f".{weight_name}." not in name:
                     continue
 
                 if "mlp.experts" in name:
@@ -1025,11 +1086,12 @@ class Qwen3_5Model(Qwen3NextModel):
                     if is_pp_missing_parameter(name, self):
                         continue
                     if name not in params_dict:
+                        if _is_qwen35_gguf_projection_aux_param(name):
+                            _append_qwen35_load_debug(f"MISSING name={name}")
+                            continue
                         logger.warning_once(
                             f"Parameter {name} not found in params_dict, skip loading"
                         )
-                        if "linear_attn.in_proj" in name:
-                            _append_qwen35_load_debug(f"MISSING name={name}")
                         continue
                     param = params_dict[name]
                     weight_loader = getattr(
@@ -1046,6 +1108,32 @@ class Qwen3_5Model(Qwen3NextModel):
                             f"is_gguf_weight_type={getattr(param, 'is_gguf_weight_type', False)} "
                             f"loaded_shape={tuple(loaded_weight.shape) if hasattr(loaded_weight, 'shape') else 'NA'}"
                         )
+                    if getattr(param, "is_gguf_weight", False) or getattr(
+                        param, "is_gguf_weight_type", False
+                    ):
+                        if getattr(param, "is_gguf_weight_type", False):
+                            param.weight_type = loaded_weight.item()
+                        else:
+                            output_dim = getattr(param, "output_dim", 0)
+                            tp_size = get_tensor_model_parallel_world_size()
+                            tp_rank = get_tensor_model_parallel_rank()
+                            local_shard = loaded_weight.size(output_dim) // tp_size
+                            start_idx = tp_rank * local_shard
+                            loaded_weight = loaded_weight.narrow(
+                                output_dim, start_idx, local_shard
+                            )
+                            loaded_weight = loaded_weight.to(device=param.device)
+                            loaded_param = torch.nn.Parameter(
+                                loaded_weight.contiguous(), requires_grad=False
+                            )
+                            for attr_name, attr_value in vars(param).items():
+                                setattr(loaded_param, attr_name, attr_value)
+                            module_name, _, param_leaf = name.rpartition(".")
+                            module = modules_dict[module_name]
+                            module.register_parameter(param_leaf, loaded_param)
+                            params_dict[name] = loaded_param
+                        loaded_params.add(name)
+                        continue
                     try:
                         weight_loader(param, loaded_weight)
                     except AssertionError as exc:

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -37,6 +37,7 @@ from vllm.model_executor.layers.fla.ops import (
     fused_recurrent_gated_delta_rule_packed_decode,
     fused_recurrent_gated_delta_rule,
     fused_sigmoid_gating_delta_rule_update,
+    fused_sigmoid_gating_delta_rule_update_kv_cache_gfx906,
 )
 from vllm.model_executor.layers.fused_moe import SharedFusedMoE
 from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
@@ -490,21 +491,35 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
     def rearrange_mixed_qkv(self, mixed_qkv):
         if mixed_qkv is None:
             return None, None, None
+        seq_len = mixed_qkv.shape[0]
+        q_dim = self.key_dim // self.tp_size
+        k_dim = self.key_dim // self.tp_size
+        v_dim = self.value_dim // self.tp_size
         query, key, value = torch.split(
             mixed_qkv,
             [
-                self.key_dim // self.tp_size,
-                self.key_dim // self.tp_size,
-                self.value_dim // self.tp_size,
+                q_dim,
+                k_dim,
+                v_dim,
             ],
             dim=-1,
         )
-        query, key = map(
-            lambda x: rearrange(x, "l (h d) -> 1 l h d", d=self.head_k_dim),
-            (query, key),
+
+        fused = torch.cat(
+            [query.reshape(-1), key.reshape(-1), value.reshape(-1)], dim=0
         )
-        value = rearrange(value, "l (h d) -> 1 l h d", d=self.head_v_dim)
-        return query.contiguous(), key.contiguous(), value.contiguous()
+
+        q_numel = seq_len * q_dim
+        k_numel = seq_len * k_dim
+        v_numel = seq_len * v_dim
+        query = fused[:q_numel].view(1, seq_len, -1, self.head_k_dim)
+        key = fused[q_numel : q_numel + k_numel].view(
+            1, seq_len, -1, self.head_k_dim
+        )
+        value = fused[q_numel + k_numel : q_numel + k_numel + v_numel].view(
+            1, seq_len, -1, self.head_v_dim
+        )
+        return query, key, value
 
     def _expand_qk_heads_for_gdn(
         self,
@@ -522,6 +537,12 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
 
     def _use_gfx906_chunk_decode_path(self) -> bool:
         return True
+
+    def _use_gfx906_packed_decode_path(self) -> bool:
+        return False
+
+    def _use_tiled_qk_head_mapping_for_packed_decode(self) -> bool:
+        return False
 
     def forward(
         self,
@@ -580,6 +601,62 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
         output[:num_tokens], _ = self.out_proj(core_attn_out)
 
+    def _forward_core_decode_packed_gfx906(
+        self,
+        mixed_qkv: torch.Tensor,
+        b: torch.Tensor,
+        a: torch.Tensor,
+        core_attn_out: torch.Tensor,
+        attn_metadata: GDNAttentionMetadata,
+    ) -> None:
+        non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor
+        assert non_spec_state_indices_tensor is not None
+
+        forward_context = get_forward_context()
+        self_kv_cache = self.kv_cache[forward_context.virtual_engine]
+        conv_state = self_kv_cache[0].transpose(-1, -2)
+        ssm_state = self_kv_cache[1]
+        num_actual_tokens = attn_metadata.num_actual_tokens
+
+        mixed_qkv = mixed_qkv[:num_actual_tokens]
+        b = b[:num_actual_tokens]
+        a = a[:num_actual_tokens]
+
+        conv_weights = self.conv1d.weight.view(
+            self.conv1d.weight.size(0), self.conv1d.weight.size(2)
+        )
+        mixed_qkv = causal_conv1d_update(
+            mixed_qkv,
+            conv_state,
+            conv_weights,
+            self.conv1d.bias,
+            self.activation,
+            conv_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],
+            validate_data=True,
+        )
+
+        out_buf = core_attn_out[:num_actual_tokens].unsqueeze(1)
+        fused_recurrent_gated_delta_rule_packed_decode(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=self.A_log,
+            dt_bias=self.dt_bias,
+            scale=self.head_k_dim**-0.5,
+            initial_state=ssm_state,
+            out=out_buf,
+            ssm_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],
+            use_qk_l2norm_in_kernel=getattr(
+                self, "use_qk_l2norm_in_kernel_for_gdn", True
+            ),
+            use_tiled_qk_head_mapping=(
+                self._use_tiled_qk_head_mapping_for_packed_decode()
+            ),
+            use_transposed_state=getattr(
+                self, "use_transposed_state_for_packed_decode", False
+            ),
+        )
+
     def _forward_core(
         self,
         mixed_qkv: torch.Tensor,
@@ -600,6 +677,25 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
         assert isinstance(attn_metadata, dict)
         attn_metadata = attn_metadata[self.prefix]
         assert isinstance(attn_metadata, GDNAttentionMetadata)
+        capability = current_platform.get_device_capability()
+        if (
+            self._use_gfx906_packed_decode_path()
+            and attn_metadata.spec_sequence_masks is None
+            and attn_metadata.num_prefills == 0
+            and attn_metadata.num_decodes > 0
+            and current_platform.is_rocm()
+            and capability is not None
+            and capability.major == 9
+            and capability.minor == 0
+        ):
+            self._forward_core_decode_packed_gfx906(
+                mixed_qkv=mixed_qkv,
+                b=b,
+                a=a,
+                core_attn_out=core_attn_out,
+                attn_metadata=attn_metadata,
+            )
+            return
         has_initial_state = attn_metadata.has_initial_state
         spec_query_start_loc = attn_metadata.spec_query_start_loc
         non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
@@ -694,24 +790,32 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 query_non_spec, key_non_spec
             )
 
-        g, beta = fused_gdn_gating(self.A_log, a, b, self.dt_bias)
+        g: torch.Tensor | None = None
+        beta: torch.Tensor | None = None
+        g_spec: torch.Tensor | None = None
+        beta_spec: torch.Tensor | None = None
+        g_non_spec: torch.Tensor | None = None
+        beta_non_spec: torch.Tensor | None = None
 
-        if spec_sequence_masks is not None:
-            if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
-                g_spec = g
-                beta_spec = beta
-                g_non_spec = None
-                beta_non_spec = None
+        def ensure_gating() -> None:
+            nonlocal g, beta, g_spec, beta_spec, g_non_spec, beta_non_spec
+            if g is not None:
+                return
+            g, beta = fused_gdn_gating(self.A_log, a, b, self.dt_bias)
+            if spec_sequence_masks is not None:
+                if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
+                    g_spec = g
+                    beta_spec = beta
+                    g_non_spec = None
+                    beta_non_spec = None
+                else:
+                    g_spec = g.index_select(1, spec_token_indx)
+                    beta_spec = beta.index_select(1, spec_token_indx)
+                    g_non_spec = g.index_select(1, non_spec_token_indx)
+                    beta_non_spec = beta.index_select(1, non_spec_token_indx)
             else:
-                g_spec = g.index_select(1, spec_token_indx)
-                beta_spec = beta.index_select(1, spec_token_indx)
-                g_non_spec = g.index_select(1, non_spec_token_indx)
-                beta_non_spec = beta.index_select(1, non_spec_token_indx)
-        else:
-            g_spec = None
-            beta_spec = None
-            g_non_spec = g
-            beta_non_spec = beta
+                g_non_spec = g
+                beta_non_spec = beta
 
         # 2. Recurrent attention
         use_qk_l2norm_in_kernel = getattr(
@@ -720,6 +824,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
 
         # 2.1: Process the multi-query part
         if spec_sequence_masks is not None:
+            ensure_gating()
+            assert g_spec is not None
+            assert beta_spec is not None
             spec_initial_state = ssm_state.transpose(-1, -2).contiguous()
             core_attn_out_spec, last_recurrent_state = fused_recurrent_gated_delta_rule(
                 q=query_spec,
@@ -768,6 +875,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 and capability.major == 9
                 and capability.minor == 0
             )
+            prefill_state_is_cache_layout = False
             if use_sigmoid_prefill_for_split_qwen35:
                 if spec_sequence_masks is not None:
                     a_non_spec = a.index_select(0, non_spec_token_indx)
@@ -792,6 +900,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                     )
                 )
             elif getattr(self, "use_recurrent_prefill_for_gdn", False):
+                ensure_gating()
+                assert g_non_spec is not None
+                assert beta_non_spec is not None
                 core_attn_out_non_spec, last_recurrent_state = (
                     fused_recurrent_gated_delta_rule(
                         q=query_non_spec,
@@ -806,25 +917,33 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                     )
                 )
             else:
+                ensure_gating()
+                assert g_non_spec is not None
+                assert beta_non_spec is not None
                 (
                     core_attn_out_non_spec,
                     last_recurrent_state,
                 ) = chunk_gated_delta_rule(
-                    q=query_non_spec.transpose(1, 2),
-                    k=key_non_spec.transpose(1, 2),
-                    v=value_non_spec.transpose(1, 2),
-                    g=g_non_spec.transpose(1, 2),
-                    beta=beta_non_spec.transpose(1, 2),
+                    q=query_non_spec,
+                    k=key_non_spec,
+                    v=value_non_spec,
+                    g=g_non_spec,
+                    beta=beta_non_spec,
                     initial_state=initial_state,
                     output_final_state=True,
                     cu_seqlens=non_spec_query_start_loc,
-                    head_first=True,
                     use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
                 )
+                prefill_state_is_cache_layout = True
             # Init cache
-            ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.transpose(
-                -1, -2
-            ).to(ssm_state.dtype)
+            if prefill_state_is_cache_layout:
+                ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.to(
+                    ssm_state.dtype
+                )
+            else:
+                ssm_state[non_spec_state_indices_tensor] = (
+                    last_recurrent_state.transpose(-1, -2).to(ssm_state.dtype)
+                )
         elif attn_metadata.num_decodes > 0:
             if getattr(self, "prefix", "") == "language_model.model.layers.0.linear_attn":
                 _append_qwen35_runtime_debug(
@@ -849,29 +968,24 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 and capability.major == 9
                 and capability.minor == 0
             ):
-                initial_state = ssm_state[non_spec_state_indices_tensor].transpose(
-                    -1, -2
-                ).contiguous()
                 (
                     core_attn_out_non_spec,
                     last_recurrent_state,
-                ) = chunk_gated_delta_rule(
-                    q=query_non_spec.transpose(1, 2),
-                    k=key_non_spec.transpose(1, 2),
-                    v=value_non_spec.transpose(1, 2),
-                    g=g_non_spec.transpose(1, 2),
-                    beta=beta_non_spec.transpose(1, 2),
-                    initial_state=initial_state,
-                    output_final_state=True,
-                    cu_seqlens=non_spec_query_start_loc[
-                        : attn_metadata.num_decodes + 1
-                    ],
-                    head_first=True,
-                    use_qk_l2norm_in_kernel=True,
+                ) = fused_sigmoid_gating_delta_rule_update_kv_cache_gfx906(
+                    A_log=self.A_log,
+                    a=a,
+                    b=b,
+                    dt_bias=self.dt_bias,
+                    q=query_non_spec,
+                    k=key_non_spec,
+                    v=value_non_spec,
+                    beta=1.0,
+                    threshold=20.0,
+                    scale=self.head_k_dim**-0.5,
+                    initial_state=ssm_state,
+                    ssm_state_indices=non_spec_state_indices_tensor,
+                    use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
                 )
-                ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.transpose(
-                    -1, -2
-                ).to(ssm_state.dtype)
             else:
                 force_local_recurrent_decode = (
                     getattr(self, "use_local_recurrent_decode_for_gdn", False)
@@ -911,6 +1025,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                     )
                     core_attn_out_non_spec = core_attn_out_packed.transpose(0, 1)
                 else:
+                    ensure_gating()
+                    assert g_non_spec is not None
+                    assert beta_non_spec is not None
                     initial_state = ssm_state.transpose(-1, -2).contiguous()
                     core_attn_out_non_spec, last_recurrent_state = (
                         fused_recurrent_gated_delta_rule(

--- a/vllm/parser/__init__.py
+++ b/vllm/parser/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.parser.abstract_parser import Parser, StreamState
+
+__all__ = [
+    "Parser",
+    "StreamState",
+]

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from vllm.entrypoints.chat_utils import make_tool_call_id
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.protocol import (
+        ChatCompletionRequest,
+        DeltaMessage,
+        ExtractedToolCallInformation,
+        FunctionCall,
+        ResponsesRequest,
+    )
+    from vllm.reasoning.abs_reasoning_parsers import ReasoningParser
+    from vllm.tokenizers import TokenizerLike
+    from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import (
+        ToolParser,
+    )
+
+
+@dataclass
+class StreamState:
+    """Mutable state for parser-engine streaming."""
+
+    reasoning_ended: bool = False
+    tool_call_text_started: bool = False
+    prompt_reasoning_checked: bool = False
+    previous_text: str = ""
+    previous_token_ids: list[int] = field(default_factory=list)
+    history_tool_call_cnt: int = 0
+    history_tool_call_cnt_initialized: bool = False
+    tool_call_id_type: str = "random"
+    function_name_returned: bool = False
+    engine_based: bool = False
+
+    def advance(
+        self,
+        delta_text: str,
+        delta_token_ids: list[int],
+    ) -> tuple[str, list[int]]:
+        if self.engine_based:
+            return delta_text, delta_token_ids
+        return (
+            self.previous_text + delta_text,
+            self.previous_token_ids + delta_token_ids,
+        )
+
+    def commit(self, current_text: str, current_token_ids: list[int]) -> None:
+        if self.engine_based:
+            self.previous_text = ""
+            self.previous_token_ids = []
+        else:
+            self.previous_text = current_text
+            self.previous_token_ids = current_token_ids
+
+
+class Parser(ABC):
+    """Small compatibility surface used by parser engines."""
+
+    reasoning_parser_cls: type["ReasoningParser"] | None = None
+    tool_parser_cls: type["ToolParser"] | None = None
+
+    def __init__(
+        self,
+        tokenizer: "TokenizerLike",
+        tools: list | None = None,
+        *args,
+        model_config=None,
+        **kwargs,
+    ) -> None:
+        self.model_tokenizer = tokenizer
+        self._reasoning_parser: ReasoningParser | None = None
+        self._tool_parser: ToolParser | None = None
+        self._stream_state = StreamState()
+
+    @cached_property
+    def vocab(self) -> dict[str, int]:
+        return self.model_tokenizer.get_vocab()
+
+    @property
+    def reasoning_parser(self) -> "ReasoningParser | None":
+        return self._reasoning_parser
+
+    @reasoning_parser.setter
+    def reasoning_parser(self, parser: "ReasoningParser | None") -> None:
+        self._reasoning_parser = parser
+
+    @property
+    def tool_parser(self) -> "ToolParser | None":
+        return self._tool_parser
+
+    @tool_parser.setter
+    def tool_parser(self, parser: "ToolParser | None") -> None:
+        self._tool_parser = parser
+
+    def _make_tool_call_id(self, function_name: str) -> str | None:
+        state = self._stream_state
+        if state.tool_call_id_type != "kimi_k2":
+            return None
+        tool_call_id = make_tool_call_id(
+            id_type=state.tool_call_id_type,
+            func_name=function_name,
+            idx=state.history_tool_call_cnt,
+        )
+        state.history_tool_call_cnt += 1
+        return tool_call_id
+
+    @abstractmethod
+    def is_reasoning_end(self, input_ids: list[int]) -> bool:
+        ...
+
+    @abstractmethod
+    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
+        ...
+
+    @abstractmethod
+    def extract_reasoning(
+        self,
+        model_output: str,
+        request: "ChatCompletionRequest | ResponsesRequest",
+    ) -> tuple[str | None, str | None]:
+        ...
+
+    @abstractmethod
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> "DeltaMessage | None":
+        ...
+
+    @abstractmethod
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: "ChatCompletionRequest | ResponsesRequest",
+    ) -> "ExtractedToolCallInformation":
+        ...
+
+    @abstractmethod
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: "ChatCompletionRequest | ResponsesRequest",
+    ) -> "DeltaMessage | None":
+        ...
+
+    @abstractmethod
+    def parse(
+        self,
+        model_output: str,
+        request: "ChatCompletionRequest | ResponsesRequest",
+        enable_auto_tools: bool = False,
+        model_output_token_ids: Sequence[int] = (),
+    ) -> tuple[str | None, str | None, list["FunctionCall"] | None]:
+        ...
+
+    @abstractmethod
+    def parse_delta(
+        self,
+        delta_text: str,
+        delta_token_ids: list[int],
+        request: "ChatCompletionRequest | ResponsesRequest",
+        prompt_token_ids: list[int] | None = None,
+        *,
+        finished: bool,
+    ) -> "DeltaMessage | None":
+        ...

--- a/vllm/parser/engine/__init__.py
+++ b/vllm/parser/engine/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Streaming parser engine framework for tool call and reasoning extraction.
+
+Instead of hand-rolling a parser for every model's tool-call / reasoning
+format, each format is declared as a ParserEngineConfig (terminals,
+states, and transitions) and a shared incremental engine handles
+streaming, ambiguity buffering, token-ID mapping, and delta computation.
+"""
+
+from vllm.parser.engine.events import EventType, SemanticEvent
+
+__all__ = [
+    "EventType",
+    "SemanticEvent",
+]

--- a/vllm/parser/engine/adapters.py
+++ b/vllm/parser/engine/adapters.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Adapters that expose :class:`ParserEngine` through the legacy
+:class:`ReasoningParser` and :class:`ToolParser` interfaces.
+
+This lets parser engines flow through the existing serving-layer code
+paths that expect separate reasoning and tool parser instances, without
+any changes to the serving layer itself.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from vllm.parser.engine.parser_engine_config import ParserState
+from vllm.reasoning.abs_reasoning_parsers import ReasoningParser
+from vllm.entrypoints.openai.tool_parsers.abstract_tool_parser import ToolParser
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.protocol import (
+        ChatCompletionRequest,
+        DeltaMessage,
+        ExtractedToolCallInformation,
+        ResponsesRequest,
+    )
+    from vllm.parser.engine.parser_engine import ParserEngine
+    from vllm.tokenizers import TokenizerLike
+    from vllm.entrypoints.openai.tool_parsers.utils import Tool
+
+
+class ParserEngineReasoningAdapter(ReasoningParser):
+    """Adapts a :class:`ParserEngine` to the :class:`ReasoningParser`
+    interface so parser engines can be used as reasoning parsers in the
+    existing serving code.
+
+    Subclasses set :attr:`_parser_engine_cls` to the concrete
+    :class:`ParserEngine` class.
+    """
+
+    _parser_engine_cls: type[ParserEngine]
+    engine_based_streaming: bool = True
+
+    def __init__(self, tokenizer: TokenizerLike, *args, **kwargs) -> None:
+        super().__init__(tokenizer, *args, **kwargs)
+        self._parser_engine = self._parser_engine_cls(tokenizer, **kwargs)  # type: ignore[call-arg]
+
+    @contextmanager
+    def _skip_tool_parsing(self) -> Iterator[None]:
+        saved = self._parser_engine.skip_tool_parsing
+        self._parser_engine.skip_tool_parsing = True
+        try:
+            yield
+        finally:
+            self._parser_engine.skip_tool_parsing = saved
+
+    def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
+        return self._parser_engine.is_reasoning_end(list(input_ids))
+
+    def adjust_initial_state_from_prompt(self, prompt_token_ids: Sequence[int]) -> None:
+        self._parser_engine.adjust_initial_state_from_prompt(prompt_token_ids)
+
+    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
+        return self._parser_engine.extract_content_ids(input_ids)
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> tuple[str | None, str | None]:
+        with self._skip_tool_parsing():
+            return self._parser_engine.extract_reasoning(model_output, request)
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> DeltaMessage | None:
+        with self._skip_tool_parsing():
+            return self._parser_engine.extract_reasoning_streaming(
+                previous_text,
+                current_text,
+                delta_text,
+                previous_token_ids,
+                current_token_ids,
+                delta_token_ids,
+            )
+
+    @property
+    def reasoning_start_str(self) -> str | None:
+        return self._parser_engine.reasoning_start_str
+
+    @property
+    def reasoning_end_str(self) -> str | None:
+        return self._parser_engine.reasoning_end_str
+
+    def adjust_request(
+        self,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        return self._parser_engine.adjust_request(request)
+
+    def has_engine_confirmed_reasoning_end(self) -> bool:
+        return self._parser_engine.reasoning_ended
+
+    def finish_streaming(self) -> DeltaMessage | None:
+        return self._parser_engine.finish_streaming()
+
+    def get_streaming_fallback_content(
+        self,
+        text: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> str | None:
+        return self._parser_engine.get_streaming_fallback_content(text, request)
+
+    def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+        return self._parser_engine.count_reasoning_tokens(token_ids)
+
+
+class ParserEngineToolAdapter(ToolParser):
+    """Adapts a :class:`ParserEngine` to the :class:`ToolParser` interface.
+
+    :meth:`extract_tool_calls` starts the parser engine in ``CONTENT``
+    state so it can parse reasoning-stripped content (i.e. the output of
+    :meth:`ReasoningParser.extract_reasoning`).
+
+    Subclasses set :attr:`_parser_engine_cls` to the concrete
+    :class:`ParserEngine` class.
+    """
+
+    _parser_engine_cls: type[ParserEngine]
+    engine_based_streaming: bool = True
+
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[Tool] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(tokenizer)
+        self._parser_engine = self._parser_engine_cls(tokenizer, tools, **kwargs)  # type: ignore[call-arg]
+
+    def adjust_request(
+        self,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        request = super().adjust_request(request)
+        return self._parser_engine.adjust_request(request)
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        return self._parser_engine.extract_tool_calls_from_content(
+            model_output, request
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> DeltaMessage | None:
+        engine = self._parser_engine
+        engine.initialize_streaming(initial_state=ParserState.CONTENT)
+        return engine.extract_tool_calls_streaming(
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+            request,
+        )
+
+    def finish_streaming(self) -> DeltaMessage | None:
+        return self._parser_engine.finish_streaming()
+
+
+def make_adapters(
+    parser_engine_cls: type[ParserEngine],
+) -> tuple[type[ParserEngineReasoningAdapter], type[ParserEngineToolAdapter]]:
+    reasoning_adapter = type(
+        f"{parser_engine_cls.__name__}ReasoningAdapter",
+        (ParserEngineReasoningAdapter,),
+        {"_parser_engine_cls": parser_engine_cls},
+    )
+    tool_adapter = type(
+        f"{parser_engine_cls.__name__}ToolAdapter",
+        (ParserEngineToolAdapter,),
+        {"_parser_engine_cls": parser_engine_cls},
+    )
+    # Let the serving layer find the adapters and call adjust_request(),
+    # which sets skip_special_tokens=False for the detokenizer.
+    parser_engine_cls.reasoning_parser_cls = reasoning_adapter  # type: ignore[attr-defined]
+    parser_engine_cls.tool_parser_cls = tool_adapter  # type: ignore[attr-defined]
+    return reasoning_adapter, tool_adapter

--- a/vllm/parser/engine/events.py
+++ b/vllm/parser/engine/events.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Semantic event types emitted by the streaming parser engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+class EventType(Enum):
+    TEXT_CHUNK = auto()
+    REASONING_START = auto()
+    REASONING_CHUNK = auto()
+    REASONING_END = auto()
+    TOOL_CALL_START = auto()
+    TOOL_NAME = auto()
+    ARG_VALUE_CHUNK = auto()
+    TOOL_CALL_END = auto()
+
+
+@dataclass(slots=True)
+class SemanticEvent:
+    type: EventType
+    value: str = ""
+    tool_index: int = -1

--- a/vllm/parser/engine/incremental_lexer.py
+++ b/vllm/parser/engine/incremental_lexer.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Incremental text lexer that converts text chunks into terminal
+tokens, with prefix-match buffering for ambiguous boundaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import regex as re
+
+CONTENT_TERMINAL = "__CONTENT__"
+
+
+@dataclass(slots=True)
+class TerminalDef:
+    name: str
+    pattern: re.Pattern[str]
+    is_literal: bool = False
+    literal: str = ""
+
+
+@dataclass(slots=True)
+class LexToken:
+    terminal: str
+    value: str
+
+
+class LexerShape:
+    """Immutable pre-computed data derived from terminal definitions.
+
+    Created once per :class:`ParserEngineConfig` and shared across all
+    :class:`IncrementalLexer` instances that use the same config.
+    """
+
+    __slots__ = (
+        "terminals",
+        "literal_strings",
+        "max_literal_len",
+        "literal_first_chars",
+        "has_only_literals",
+        "prefix_set",
+        "literals_by_first",
+    )
+
+    def __init__(self, terminals: list[TerminalDef]) -> None:
+        self.terminals = sorted(
+            terminals,
+            key=lambda t: (not t.is_literal, -len(t.pattern.pattern)),
+        )
+        literal_strings: list[tuple[str, str]] = []
+        for t in self.terminals:
+            if t.is_literal:
+                literal_strings.append((t.literal, t.name))
+
+        self.literal_strings = literal_strings
+        max_len = 0
+        for lit, _ in literal_strings:
+            if len(lit) > max_len:
+                max_len = len(lit)
+        self.max_literal_len = max_len
+        self.literal_first_chars = frozenset(
+            lit[0] for lit, _ in literal_strings if lit
+        )
+        self.has_only_literals = all(t.is_literal for t in terminals)
+
+        prefix_set: set[str] = set()
+        for lit, _ in literal_strings:
+            for i in range(1, len(lit)):
+                prefix_set.add(lit[:i])
+        self.prefix_set = frozenset(prefix_set)
+
+        by_first: dict[str, list[tuple[str, str]]] = {}
+        for lit, name in literal_strings:
+            if lit:
+                by_first.setdefault(lit[0], []).append((lit, name))
+        self.literals_by_first = by_first
+
+
+class IncrementalLexer:
+    """Converts streaming text into terminal tokens.
+
+    The key feature is **prefix-match buffering**: when the text in the
+    buffer could be the start of a multi-character terminal (e.g.
+    ``"<tool_"`` that could become ``"<tool_call>"``), the lexer holds
+    the text rather than emitting it.  When the next chunk arrives, it
+    either completes the terminal or flushes the buffered text as
+    content.
+
+    Terminals are tried in priority order (literals first, then by
+    descending priority, then by pattern length).
+    """
+
+    def __init__(
+        self,
+        terminals: list[TerminalDef] | LexerShape,
+        content_terminal: str = CONTENT_TERMINAL,
+    ) -> None:
+        if isinstance(terminals, LexerShape):
+            shape = terminals
+        else:
+            shape = LexerShape(terminals)
+        self._shape = shape
+        self.terminals = shape.terminals
+        self.content_terminal = content_terminal
+        self.buffer = ""
+
+        self._literal_strings = shape.literal_strings
+        self._max_literal_len = shape.max_literal_len
+        self._literal_first_chars = shape.literal_first_chars
+        self._has_only_literals = shape.has_only_literals
+        self._prefix_set = shape.prefix_set
+        self._literals_by_first = shape.literals_by_first
+
+    def reset(self) -> None:
+        self.buffer = ""
+
+    def feed(self, text: str) -> list[LexToken]:
+        if not self.buffer and self._has_only_literals and self._literal_first_chars:
+            for ch in text:
+                if ch in self._literal_first_chars:
+                    break
+            else:
+                return [LexToken(self.content_terminal, text)]
+        self.buffer += text
+        return self._drain()
+
+    def flush(self) -> list[LexToken]:
+        tokens: list[LexToken] = []
+        if self.buffer:
+            tokens.extend(self._drain(final=True))
+        if self.buffer:
+            tokens.append(LexToken(self.content_terminal, self.buffer))
+            self.buffer = ""
+        return tokens
+
+    def _drain(self, *, final: bool = False) -> list[LexToken]:
+        tokens: list[LexToken] = []
+        first_chars = self._literal_first_chars
+        content_terminal = self.content_terminal
+        has_only_literals = self._has_only_literals
+        literals_by_first = self._literals_by_first
+        prefix_set = self._prefix_set
+
+        while self.buffer:
+            if has_only_literals and first_chars:
+                has_potential = False
+                for ch in self.buffer:
+                    if ch in first_chars:
+                        has_potential = True
+                        break
+                if not has_potential:
+                    tokens.append(LexToken(content_terminal, self.buffer))
+                    self.buffer = ""
+                    break
+
+            best_match: tuple[str, str, int] | None = None
+
+            first = self.buffer[0]
+            for lit, name in literals_by_first.get(first, ()):
+                if self.buffer.startswith(lit) and (
+                    best_match is None or len(lit) > best_match[2]
+                ):
+                    best_match = (name, lit, len(lit))
+
+            # If the current buffer is both a complete literal and the prefix
+            # of a longer literal, wait for the next chunk. For example,
+            # "<invoke name=" should not be emitted before the next chunk
+            # proves whether this is the quoted form '<invoke name="'.
+            if self.buffer in prefix_set and not final:
+                if best_match is not None:
+                    longer_match = False
+                    for lit, _ in literals_by_first.get(first, ()):
+                        if len(lit) > best_match[2] and lit.startswith(self.buffer):
+                            longer_match = True
+                            break
+                    if not longer_match:
+                        tokens.append(LexToken(best_match[0], best_match[1]))
+                        self.buffer = self.buffer[best_match[2] :]
+                        continue
+                    break
+                else:
+                    break
+
+            if best_match is not None:
+                tokens.append(LexToken(best_match[0], best_match[1]))
+                self.buffer = self.buffer[best_match[2] :]
+            else:
+                content_end = self._find_content_boundary()
+                if content_end > 0:
+                    tokens.append(LexToken(content_terminal, self.buffer[:content_end]))
+                    self.buffer = self.buffer[content_end:]
+                else:
+                    tokens.append(LexToken(content_terminal, self.buffer[0]))
+                    self.buffer = self.buffer[1:]
+
+        return tokens
+
+    def _find_content_boundary(self) -> int:
+        buf = self.buffer
+        n = len(buf)
+        first_chars = self._literal_first_chars
+        for i in range(1, n):
+            if buf[i] not in first_chars:
+                continue
+            remaining = n - i
+            for lit, _ in self._literal_strings:
+                check_len = min(remaining, len(lit))
+                if buf[i : i + check_len] == lit[:check_len]:
+                    return i
+        return n
+
+
+def terminals_from_literals(literals: dict[str, str]) -> list[TerminalDef]:
+    return [
+        TerminalDef(
+            name=name,
+            pattern=re.compile(re.escape(lit)),
+            is_literal=True,
+            literal=lit,
+        )
+        for name, lit in literals.items()
+    ]

--- a/vllm/parser/engine/parser_engine.py
+++ b/vllm/parser/engine/parser_engine.py
@@ -1,0 +1,1085 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Parser engine base that handles both reasoning and tool call
+extraction with a single :class:`StreamingParserEngine`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+import regex as re
+
+from vllm.entrypoints.chat_utils import make_tool_call_id
+from vllm.entrypoints.openai.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.logger import init_logger
+from vllm.parser.abstract_parser import Parser, StreamState
+from vllm.parser.engine.events import EventType, SemanticEvent
+from vllm.parser.engine.parser_engine_config import ParserEngineConfig, ParserState
+from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
+from vllm.entrypoints.openai.tool_parsers.utils import (
+    coerce_to_schema_type,
+    extract_types_from_schema,
+    find_tool_name,
+    find_tool_properties,
+)
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.protocol import (
+        ChatCompletionRequest,
+        ResponsesRequest,
+    )
+    from vllm.tokenizers import TokenizerLike
+    from vllm.entrypoints.openai.tool_parsers.utils import Tool
+
+logger = init_logger(__name__)
+
+
+def _get_tool_call_id_type(model_config) -> str:
+    if model_config is not None and model_config.hf_config.model_type == "kimi_k2":
+        return "kimi_k2"
+    return "random"
+
+
+class ToolCallSlot:
+    __slots__ = (
+        "id",
+        "name",
+        "_args_parts",
+        "_args_joined",
+        "name_sent",
+        "string_keys",
+        "streamed_json",
+    )
+
+    def __init__(self) -> None:
+        self.id: str = ""
+        self.name: str = ""
+        self._args_parts: list[str] = []
+        self._args_joined: str | None = ""
+        self.name_sent: bool = False
+        self.string_keys: set[str] | None = None
+        self.streamed_json: str = ""
+
+    @property
+    def args(self) -> str:
+        if self._args_joined is None:
+            self._args_joined = "".join(self._args_parts)
+        return self._args_joined
+
+    def append_args(self, value: str) -> None:
+        self._args_parts.append(value)
+        self._args_joined = None
+
+
+class ParserEngine(Parser):
+    """A :class:`Parser` backed by a single declarative engine config.
+
+    Subclasses set the ``ParserEngineConfig`` in ``__init__`` to define the
+    complete output format for a model (reasoning + tool calls).
+    """
+
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[Tool] | None = None,
+        *,
+        parser_engine_config: ParserEngineConfig,
+        model_config=None,
+        **kwargs,
+    ) -> None:
+        self.model_tokenizer = tokenizer
+        self._tools = tools
+        self._stream_state = StreamState(
+            tool_call_id_type=(
+                _get_tool_call_id_type(model_config)
+                if model_config is not None
+                else "random"
+            ),
+        )
+        self._reasoning_parser = None
+        self._tool_parser = None
+        self.parser_engine_config = parser_engine_config
+        self._engine = StreamingParserEngine(
+            parser_engine_config, tokenizer, vocab=self.vocab
+        )
+
+        self._reasoning_ended: bool = False
+        self._streaming_initialized: bool = False
+        self._prompt_streaming_prepared: bool = False
+
+        self._tool_slots: list[ToolCallSlot] = []
+        self._deferred_content: str = ""
+        self._deferred_reasoning: str = ""
+        self._content_has_nonws: bool = False
+
+        self._arg_converter = parser_engine_config.arg_converter
+        self._arg_structural_chars = parser_engine_config.arg_structural_chars
+        self._stream_arg_deltas = parser_engine_config.stream_arg_deltas
+        self._strip_trailing_reasoning_ws = (
+            parser_engine_config.strip_trailing_reasoning_whitespace
+        )
+        self._drop_ws_only_content_before_tools = (
+            parser_engine_config.drop_whitespace_only_content_before_tools
+        )
+        self._strip_content_ws_with_tools = (
+            parser_engine_config.strip_content_whitespace_with_tools
+        )
+
+        vocab = self.vocab
+        self._reasoning_start_token_id: int | None = None
+        self._reasoning_end_token_id: int | None = None
+
+        start_text = parser_engine_config.token_id_terminals.get("THINK_START")
+        end_text = parser_engine_config.token_id_terminals.get("THINK_END")
+        if start_text:
+            self._reasoning_start_token_id = vocab.get(start_text)
+        if end_text:
+            self._reasoning_end_token_id = vocab.get(end_text)
+
+    @property
+    def reasoning_start_str(self) -> str | None:
+        return self.parser_engine_config.terminals.get("THINK_START")
+
+    @property
+    def reasoning_end_str(self) -> str | None:
+        return self.parser_engine_config.terminals.get("THINK_END")
+
+    @cached_property
+    def vocab(self) -> dict[str, int]:
+        return self.model_tokenizer.get_vocab()
+
+    # ── Engine lifecycle ──────────────────────────────────────────────
+
+    @property
+    def skip_tool_parsing(self) -> bool:
+        return self._engine.skip_tool_parsing
+
+    @skip_tool_parsing.setter
+    def skip_tool_parsing(self, value: bool) -> None:
+        self._engine.skip_tool_parsing = value
+
+    @property
+    def reasoning_ended(self) -> bool:
+        return self._reasoning_ended
+
+    def initialize_streaming(
+        self,
+        initial_state: ParserState | None = None,
+    ) -> None:
+        if not self._streaming_initialized:
+            self._streaming_initialized = True
+            self._reset(initial_state=initial_state)
+
+    def adjust_initial_state_from_prompt(self, prompt_token_ids: Sequence[int]) -> None:
+        """See :meth:`ReasoningParser.adjust_initial_state_from_prompt`."""
+        return
+
+    def finish_streaming(self) -> DeltaMessage | None:
+        events = self._engine.finish()
+        if events or self._deferred_content:
+            return self._events_to_delta(events, finished=True)
+        return None
+
+    def _reset(self, initial_state: ParserState | None = None) -> None:
+        self._engine.reset(initial_state=initial_state)
+        self._reasoning_ended = False
+        self._tool_slots.clear()
+        self._deferred_content = ""
+        self._deferred_reasoning = ""
+        self._content_has_nonws = False
+        self._prompt_streaming_prepared = False
+
+    def adjust_request(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        request.skip_special_tokens = False
+        return request
+
+    def _preprocess_feed(
+        self,
+        delta_text: str,
+        delta_token_ids: Sequence[int],
+    ) -> tuple[str, Sequence[int]]:
+        return delta_text, delta_token_ids
+
+    def _feed(
+        self,
+        delta_text: str,
+        delta_token_ids: Sequence[int],
+    ) -> list[SemanticEvent]:
+        delta_text, delta_token_ids = self._preprocess_feed(delta_text, delta_token_ids)
+        return self._engine.feed(delta_text, delta_token_ids)
+
+    # ── Schema-aware type correction ─────────────────────────────────
+
+    @staticmethod
+    def _coerce_value(value: object, schema: dict) -> tuple[object, bool]:
+        """Coerce a single value according to its schema.
+
+        Returns ``(coerced_value, changed)``.
+        """
+        if isinstance(value, str):
+            types = extract_types_from_schema(schema)
+            coerced = coerce_to_schema_type(value, types)
+            if coerced is not value:
+                return coerced, True
+            return value, False
+
+        if isinstance(value, dict):
+            nested_props = schema.get("properties")
+            if isinstance(nested_props, dict):
+                _, changed = ParserEngine._coerce_dict(value, nested_props)
+                return value, changed
+            return value, False
+
+        if isinstance(value, list):
+            items_schema = schema.get("items")
+            if isinstance(items_schema, dict):
+                changed = False
+                for i, item in enumerate(value):
+                    coerced, item_changed = ParserEngine._coerce_value(
+                        item, items_schema
+                    )
+                    if item_changed:
+                        value[i] = coerced
+                        changed = True
+                return value, changed
+            return value, False
+
+        types = extract_types_from_schema(schema)
+        as_str = json.dumps(value, ensure_ascii=False)
+        coerced = coerce_to_schema_type(as_str, types)
+        if coerced != value:
+            return coerced, True
+        return value, False
+
+    @staticmethod
+    def _coerce_dict(args: dict, properties: dict) -> tuple[dict, bool]:
+        """Coerce all values in *args* using *properties* schemas."""
+        changed = False
+        for key, value in args.items():
+            prop = properties.get(key)
+            if not isinstance(prop, dict):
+                continue
+            coerced, val_changed = ParserEngine._coerce_value(value, prop)
+            if val_changed:
+                args[key] = coerced
+                changed = True
+        return args, changed
+
+    @staticmethod
+    def _safe_arg_prefix(json_str: str, string_keys: set[str] | None = None) -> str:
+        """Return the prefix of *json_str* up to the last top-level value.
+
+        Middle values (followed by a comma) are stable across streaming
+        ticks and included.  The trailing value is excluded for non-string
+        values because type coercion may change its serialised form between
+        ticks, which would violate the ``startswith(prev)`` prefix invariant.
+        String values for keys in ``string_keys`` are prefix-stable, so stream
+        their unterminated content instead of buffering long arguments until
+        the closing tag arrives.
+        """
+        last_colon = -1
+        last_key: str | None = None
+        pending_key: str | None = None
+        in_string = False
+        escape = False
+        string_start = -1
+        depth = 0
+        for i, c in enumerate(json_str):
+            if escape:
+                escape = False
+                continue
+            if in_string:
+                if c == "\\":
+                    escape = True
+                elif c == '"':
+                    in_string = False
+                    if depth == 1 and string_start >= 0:
+                        pending_key = json_str[string_start + 1 : i]
+                continue
+            if c == '"':
+                in_string = True
+                string_start = i
+            elif c in ("{", "["):
+                depth += 1
+            elif c in ("}", "]"):
+                depth -= 1
+            elif c == ":" and depth == 1:
+                last_colon = i
+                last_key = pending_key
+                pending_key = None
+        if last_colon < 0:
+            return ""
+        end = last_colon + 1
+        while end < len(json_str) and json_str[end] in (" ", "\t", "\n", "\r"):
+            end += 1
+        if end >= len(json_str) or json_str[end] != '"':
+            return json_str[:end]
+        if string_keys is not None and last_key not in string_keys:
+            return json_str[:end]
+
+        escape = False
+        for i in range(end + 1, len(json_str)):
+            c = json_str[i]
+            if escape:
+                escape = False
+                continue
+            if c == "\\":
+                escape = True
+                continue
+            if c == '"':
+                return json_str[:i]
+        return json_str
+
+    @staticmethod
+    def _streamable_string_keys(properties: dict) -> set[str] | None:
+        """Return keys whose trailing string values can safely stream.
+
+        ``None`` means there is no schema, so all string values keep their
+        JSON representation as strings.  With a schema, only fields that can
+        remain strings are safe to emit before the value is closed; fields
+        coerced to bool/number/null/object/array may serialize differently.
+        """
+        if not properties:
+            return None
+
+        streamable: set[str] = set()
+        for key, schema in properties.items():
+            if set(extract_types_from_schema(schema)) == {"string"}:
+                streamable.add(key)
+        return streamable
+
+    def _fix_arg_types(self, args_json: str, func_name: str) -> str:
+        """Correct parameter types using the tool schema.
+
+        String values are coerced via :func:`coerce_to_schema_type`.
+        Nested objects and arrays are recursed into when the schema
+        defines ``properties`` or ``items``.  Without a schema, values
+        stay as strings.
+        """
+        if not self._tools or not func_name:
+            return args_json
+        try:
+            args = json.loads(args_json)
+        except (json.JSONDecodeError, ValueError):
+            return args_json
+        if not isinstance(args, dict):
+            return args_json
+
+        properties = find_tool_properties(self._tools, func_name)
+        if not properties:
+            return args_json
+
+        _, changed = self._coerce_dict(args, properties)
+
+        if changed:
+            return json.dumps(args, ensure_ascii=False)
+        return args_json
+
+    def _is_valid_tool_name(self, name: str) -> bool:
+        if not self.parser_engine_config.validate_tool_names:
+            return True
+        if not self._tools:
+            return True
+        return find_tool_name(self._tools, name)
+
+    # ── Private helpers ─────────────────────────────────────────────
+
+    def _check_skip_tool_parsing(
+        self,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> None:
+        tools = getattr(request, "tools", None)
+        if tools:
+            self._tools = tools
+        if not self.skip_tool_parsing:
+            tool_choice = getattr(request, "tool_choice", None)
+            if tool_choice == "none" and tools:
+                self.skip_tool_parsing = True
+
+    def _strip_content_whitespace(
+        self,
+        content: str,
+        tools_called: bool,
+    ) -> str | None:
+        if tools_called:
+            if self._strip_content_ws_with_tools:
+                content = content.strip()
+            elif self._drop_ws_only_content_before_tools and not content.strip():
+                content = ""
+        return content or None
+
+    # ── Streaming: parse_delta ────────────────────────────────────────
+
+    def parse_delta(
+        self,
+        delta_text: str,
+        delta_token_ids: list[int],
+        request: ChatCompletionRequest | ResponsesRequest,
+        prompt_token_ids: list[int] | None = None,
+        *,
+        finished: bool,
+    ) -> DeltaMessage | None:
+        self._initialize_history_tool_call_cnt(request)
+        if not self._prompt_streaming_prepared and prompt_token_ids is not None:
+            # NOTE: call the hook BEFORE setting the flag, because the hook
+            # may invoke ``_reset`` (e.g. via ``initialize_streaming``) which
+            # clears ``_prompt_streaming_prepared``.
+            self.adjust_initial_state_from_prompt(prompt_token_ids)
+            self._prompt_streaming_prepared = True
+        self._check_skip_tool_parsing(request)
+        events = self._feed(delta_text, delta_token_ids)
+        if finished:
+            events.extend(self._engine.finish())
+        result = self._events_to_delta(events, finished=finished)
+        return self._strip_trailing_reasoning(result)
+
+    def _strip_trailing_reasoning(
+        self,
+        delta: DeltaMessage | None,
+    ) -> DeltaMessage | None:
+        """Strip trailing whitespace from reasoning, deferring it until we
+        know whether more reasoning follows or reasoning has ended.
+
+        Runs in ``parse_delta`` *after* ``_events_to_delta`` (and any
+        subclass overrides) so that overrides see the raw reasoning text.
+
+        Gated by ``strip_trailing_reasoning_whitespace``; when disabled,
+        passes through unchanged.
+        """
+        if not self._strip_trailing_reasoning_ws:
+            return delta
+        if delta is not None and delta.reasoning is not None:
+            combined = self._deferred_reasoning + delta.reasoning
+            trimmed = combined.rstrip()
+            self._deferred_reasoning = combined[len(trimmed) :]
+            delta.reasoning = trimmed or None
+            if (
+                delta.reasoning is None
+                and delta.content is None
+                and not delta.tool_calls
+            ):
+                return None
+        elif self._deferred_reasoning and self._reasoning_ended:
+            self._deferred_reasoning = ""
+        return delta
+
+    # ── Non-streaming: extract_reasoning ──────────────────────────────
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> tuple[str | None, str | None]:
+        self._reset()
+        events = self._feed(model_output, [])
+        events.extend(self._engine.finish())
+
+        reasoning_parts: list[str] = []
+        content_parts: list[str] = []
+
+        for event in events:
+            if event.type == EventType.REASONING_CHUNK:
+                reasoning_parts.append(event.value)
+            elif event.type == EventType.TEXT_CHUNK:
+                content_parts.append(event.value)
+            elif event.type == EventType.REASONING_END:
+                self._reasoning_ended = True
+
+        raw_reasoning = "".join(reasoning_parts)
+        if self._strip_trailing_reasoning_ws:
+            raw_reasoning = raw_reasoning.rstrip()
+        reasoning = raw_reasoning or None
+        content = "".join(content_parts) or None
+        return reasoning, content
+
+    # ── Non-streaming: extract_reasoning_streaming ────────────────────
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> DeltaMessage | None:
+        self.initialize_streaming()
+        events = self._feed(delta_text, delta_token_ids)
+        return self._strip_trailing_reasoning(self._events_to_delta(events))
+
+    # ── Non-streaming: extract_tool_calls ─────────────────────────────
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> ExtractedToolCallInformation:
+        self._reset()
+        self._streaming_initialized = True
+        result = self.extract_tool_calls_streaming(
+            previous_text="",
+            current_text=model_output,
+            delta_text=model_output,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=request,
+        )
+        finish_delta = self.finish_streaming()
+        return self._build_extracted_result(result, finish_delta)
+
+    def extract_tool_calls_from_content(
+        self,
+        content: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        """Extract tool calls from reasoning-stripped content.
+
+        Unlike :meth:`extract_tool_calls` which re-parses the full model
+        output, this method starts the parser engine in ``CONTENT`` state
+        so it can parse content that has already had reasoning stripped.
+        """
+        self._check_skip_tool_parsing(request)
+        _, parsed_content, tool_call_info = self._single_pass_parse(
+            content,
+            [],
+            initial_state=ParserState.CONTENT,
+        )
+        if parsed_content is not None and tool_call_info.content is None:
+            tool_call_info = ExtractedToolCallInformation(
+                tools_called=tool_call_info.tools_called,
+                tool_calls=tool_call_info.tool_calls,
+                content=parsed_content,
+            )
+        return tool_call_info
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> DeltaMessage | None:
+        self.initialize_streaming()
+        self._check_skip_tool_parsing(request)
+        events = self._feed(delta_text, delta_token_ids)
+        return self._strip_trailing_reasoning(self._events_to_delta(events))
+
+    # ── Reasoning state queries ───────────────────────────────────────
+
+    def is_reasoning_end(self, input_ids: list[int]) -> bool:
+        end_id = self._reasoning_end_token_id
+        start_id = self._reasoning_start_token_id
+        if end_id is not None:
+            if not input_ids:
+                return self.parser_engine_config.initial_state != ParserState.REASONING
+            for i in range(len(input_ids) - 1, -1, -1):
+                if input_ids[i] == end_id:
+                    return True
+                if start_id is not None and input_ids[i] == start_id:
+                    return False
+            return False
+        return self._reasoning_ended
+
+    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
+        end_id = self._reasoning_end_token_id
+        if end_id is not None:
+            for i in range(len(input_ids) - 1, -1, -1):
+                if input_ids[i] == end_id:
+                    return input_ids[i + 1 :]
+        return input_ids
+
+    def get_streaming_fallback_content(
+        self,
+        text: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> str | None:
+        return None
+
+    def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+        start_id = self._reasoning_start_token_id
+        end_id = self._reasoning_end_token_id
+        if start_id is None or end_id is None:
+            return 0
+        count = 0
+        depth = 0
+        for token_id in token_ids:
+            if token_id == start_id:
+                depth += 1
+                continue
+            if token_id == end_id:
+                if depth > 0:
+                    depth -= 1
+                continue
+            if depth > 0:
+                count += 1
+        return count
+
+    # ── Single-pass parse helper ────────────────────────────────────────
+
+    def _single_pass_parse(
+        self,
+        text: str,
+        token_ids: Sequence[int],
+        initial_state: ParserState | None = None,
+    ) -> tuple[str | None, str | None, ExtractedToolCallInformation]:
+        """Reset, feed, finish, and extract results in one pass.
+
+        Must be called as a unit — ``_events_to_delta`` populates tool
+        state that ``_build_extracted_result`` reads.
+        """
+        self._reset(initial_state=initial_state)
+        events = self._feed(text, token_ids)
+        events.extend(self._engine.finish())
+
+        delta = self._events_to_delta(events)
+        tool_call_info = self._build_extracted_result()
+
+        reasoning = delta.reasoning if delta else None
+        if reasoning and self._strip_trailing_reasoning_ws:
+            reasoning = reasoning.rstrip() or None
+
+        content = delta.content if delta else None
+        if content:
+            content = self._strip_content_whitespace(
+                content, tool_call_info.tools_called
+            )
+
+        return reasoning, content, tool_call_info
+
+    # ── Non-streaming: parse ───────────────────────────────────────────
+
+    def parse(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+        enable_auto_tools: bool = False,
+        model_output_token_ids: Sequence[int] = (),
+    ) -> tuple[str | None, str | None, list[FunctionCall] | None]:
+        self._initialize_history_tool_call_cnt(request)
+        self._check_skip_tool_parsing(request)
+        reasoning, content, tool_call_info = self._single_pass_parse(
+            model_output,
+            model_output_token_ids,
+        )
+
+        tool_calls: list[FunctionCall] | None = None
+        if tool_call_info.tools_called:
+            tool_calls = [
+                FunctionCall(
+                    id=tc.id,
+                    name=tc.function.name,
+                    arguments=tc.function.arguments,
+                )
+                for tc in tool_call_info.tool_calls
+            ]
+
+        return reasoning, content, tool_calls
+
+    # ── Event-to-delta conversion ─────────────────────────────────────
+
+    def _events_to_delta(
+        self,
+        events: list[SemanticEvent],
+        finished: bool = False,
+    ) -> DeltaMessage | None:
+        if not events and not self._deferred_content:
+            return None
+
+        tool_call_deltas: list[DeltaToolCall] = []
+        content_parts: list[str] = []
+        reasoning_parts: list[str] = []
+
+        seen_tool_event = False
+        for event in events:
+            match event.type:
+                case EventType.TEXT_CHUNK:
+                    if seen_tool_event:
+                        self._deferred_content += event.value
+                    else:
+                        content_parts.append(event.value)
+                case EventType.REASONING_CHUNK:
+                    reasoning_parts.append(event.value)
+                case EventType.REASONING_END:
+                    self._reasoning_ended = True
+                case EventType.TOOL_CALL_START:
+                    seen_tool_event = True
+                    self._ensure_slot(event.tool_index)
+                case EventType.TOOL_NAME:
+                    seen_tool_event = True
+                    self._handle_tool_name(event)
+                case EventType.ARG_VALUE_CHUNK:
+                    seen_tool_event = True
+                    self._handle_arg_chunk(event, tool_call_deltas)
+                case EventType.TOOL_CALL_END:
+                    seen_tool_event = True
+                    self._handle_tool_end(event, tool_call_deltas)
+                case EventType.REASONING_START:
+                    pass  # no delta-level effect
+
+        if len(tool_call_deltas) > 1:
+            tool_call_deltas = self._coalesce_tool_call_deltas(tool_call_deltas)
+
+        if self._deferred_content and (not seen_tool_event or not tool_call_deltas):
+            content_parts.insert(0, self._deferred_content)
+            self._deferred_content = ""
+
+        content_str = "".join(content_parts)
+
+        if self._content_has_nonws:
+            pass
+        elif content_str:
+            stripped = content_str.strip()
+            if stripped:
+                self._content_has_nonws = True
+            elif self._tool_slots:
+                if self._drop_ws_only_content_before_tools:
+                    content_str = ""
+            elif not finished:
+                self._deferred_content = content_str
+                content_str = ""
+
+        content = content_str or None
+        reasoning = "".join(reasoning_parts) or None
+
+        if content or tool_call_deltas or reasoning:
+            kwargs: dict[str, object] = {}
+            if content is not None:
+                kwargs["content"] = content
+            if reasoning is not None:
+                kwargs["reasoning"] = reasoning
+            if tool_call_deltas:
+                kwargs["tool_calls"] = tool_call_deltas
+            return DeltaMessage(**kwargs)
+        return None
+
+    def _ensure_slot(self, idx: int) -> None:
+        while len(self._tool_slots) <= idx:
+            self._tool_slots.append(ToolCallSlot())
+
+    def _ensure_tool_id(self, slot: ToolCallSlot, name: str) -> None:
+        if not slot.id:
+            state = self._stream_state
+            slot.id = make_tool_call_id(
+                id_type=state.tool_call_id_type,
+                func_name=name,
+                idx=state.history_tool_call_cnt,
+            )
+            state.history_tool_call_cnt += 1
+
+    def _handle_tool_name(self, event: SemanticEvent) -> None:
+        idx = event.tool_index
+        self._tool_slots[idx].name += event.value
+
+    def _emit_name_delta(
+        self,
+        idx: int,
+        deltas: list[DeltaToolCall],
+        name: str | None,
+    ) -> None:
+        if not name or not self._is_valid_tool_name(name):
+            return
+        slot = self._tool_slots[idx]
+        slot.name = name
+        slot.name_sent = True
+        slot.string_keys = self._streamable_string_keys(
+            find_tool_properties(self._tools, name)
+        )
+        self._ensure_tool_id(slot, name)
+        deltas.append(
+            DeltaToolCall(
+                index=idx,
+                id=slot.id,
+                type="function",
+                function=DeltaFunctionCall(name=name),
+            )
+        )
+
+    def _handle_arg_chunk(
+        self,
+        event: SemanticEvent,
+        deltas: list[DeltaToolCall],
+    ) -> None:
+        idx = event.tool_index
+        slot = self._tool_slots[idx]
+        if event.value:
+            slot.append_args(event.value)
+
+        if not slot.name_sent:
+            if slot.name:
+                self._emit_name_delta(idx, deltas, slot.name)
+            elif event.value:
+                # Name not yet known — try to extract from accumulated args
+                name = self._try_extract_name(idx)
+                self._emit_name_delta(idx, deltas, name)
+        elif event.value:
+            # Name already sent — emit arg delta
+            arg_delta = self._compute_arg_delta(idx, event.value)
+            if arg_delta:
+                deltas.append(
+                    DeltaToolCall(
+                        index=idx,
+                        function=DeltaFunctionCall(arguments=arg_delta),
+                    )
+                )
+
+    def _handle_tool_end(
+        self,
+        event: SemanticEvent,
+        deltas: list[DeltaToolCall],
+    ) -> None:
+        idx = event.tool_index
+        if idx >= len(self._tool_slots):
+            return
+
+        remaining = self._flush_arg_converter(idx)
+        slot = self._tool_slots[idx]
+
+        if not slot.name_sent:
+            name = slot.name or self._try_extract_name(idx)
+            if name and self._is_valid_tool_name(name):
+                slot.name = name
+                slot.name_sent = True
+                slot.string_keys = self._streamable_string_keys(
+                    find_tool_properties(self._tools, name)
+                )
+                self._ensure_tool_id(slot, name)
+                deltas.append(
+                    DeltaToolCall(
+                        index=idx,
+                        id=slot.id,
+                        type="function",
+                        function=DeltaFunctionCall(
+                            name=name,
+                            arguments=remaining or "",
+                        ),
+                    )
+                )
+                remaining = None
+
+        if remaining and slot.name_sent:
+            deltas.append(
+                DeltaToolCall(
+                    index=idx,
+                    function=DeltaFunctionCall(arguments=remaining),
+                )
+            )
+
+    # ── Tool-call delta coalescing ──────────────────────────────────────
+
+    @staticmethod
+    def _coalesce_tool_call_deltas(
+        deltas: list[DeltaToolCall],
+    ) -> list[DeltaToolCall]:
+        """Merge entries that share the same index into one per index."""
+        merged: dict[int, DeltaToolCall] = {}
+        for tc in deltas:
+            existing = merged.get(tc.index)
+            if existing is None:
+                merged[tc.index] = tc
+                continue
+            if tc.id is not None and existing.id is None:
+                existing.id = tc.id
+            if tc.type is not None and existing.type is None:
+                existing.type = tc.type
+            if tc.function is not None:
+                if existing.function is None:
+                    existing.function = tc.function
+                else:
+                    if tc.function.name is not None and existing.function.name is None:
+                        existing.function.name = tc.function.name
+                    if tc.function.arguments is not None:
+                        if existing.function.arguments is None:
+                            existing.function.arguments = tc.function.arguments
+                        else:
+                            existing.function.arguments += tc.function.arguments
+        if len(merged) == len(deltas):
+            return deltas
+        return list(merged.values())
+
+    # ── Arg conversion helpers ─────────────────────────────────────────
+
+    def _compute_arg_delta(self, idx: int, raw_delta: str) -> str | None:
+        converter = self._arg_converter
+        if converter is None:
+            return raw_delta
+
+        if not self._stream_arg_deltas:
+            return None
+
+        structural = self._arg_structural_chars
+        if structural is not None and structural.isdisjoint(raw_delta):
+            return None
+
+        slot = self._tool_slots[idx]
+        try:
+            current_json = converter(slot.args, True)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            logger.debug("arg converter failed (streaming): %s", slot.args[:80])
+            return None
+
+        if not current_json:
+            return None
+
+        if slot.name:
+            current_json = self._fix_arg_types(current_json, slot.name)
+
+        prev = slot.streamed_json
+        safe_json = self._safe_arg_prefix(current_json, slot.string_keys)
+
+        if not safe_json or safe_json == prev:
+            return None
+
+        if prev:
+            if not safe_json.startswith(prev):
+                return None
+            diff = safe_json[len(prev) :]
+        else:
+            diff = safe_json
+
+        if diff:
+            slot.streamed_json = safe_json
+            return diff
+        return None
+
+    def _flush_arg_converter(self, idx: int) -> str | None:
+        converter = self._arg_converter
+        if converter is None:
+            return None
+
+        slot = self._tool_slots[idx]
+        try:
+            final_json = converter(slot.args, False)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            logger.debug("arg converter failed (flush): %s", slot.args[:80])
+            return None
+
+        if final_json:
+            final_json = self._fix_arg_types(final_json, slot.name)
+
+        prev = slot.streamed_json
+        if final_json and len(final_json) > len(prev):
+            if prev and not final_json.startswith(prev):
+                return None
+            diff = final_json[len(prev) :]
+            slot.streamed_json = final_json
+            return diff
+        return None
+
+    _NAME_RE = re.compile(r'"name"\s*:\s*"([^"]*)"')
+
+    def _try_extract_name(self, idx: int) -> str | None:
+        m = self._NAME_RE.search(self._tool_slots[idx].args)
+        if m:
+            name = m.group(1)
+            if name:
+                return name
+        return None
+
+    # ── Build ExtractedToolCallInformation ─────────────────────────────
+
+    def _build_extracted_result(
+        self,
+        *deltas: DeltaMessage | None,
+    ) -> ExtractedToolCallInformation:
+        content_parts: list[str] = []
+        for delta in deltas:
+            if delta is not None and delta.content:
+                content_parts.append(delta.content)
+
+        tool_calls: list[ToolCall] = []
+        for idx, slot in enumerate(self._tool_slots):
+            if not slot.name and not slot.args:
+                continue
+
+            name = slot.name.strip()
+            raw_body = slot.args
+
+            if not name and raw_body.strip():
+                name, args_json = self._extract_name_and_args(raw_body)
+            elif raw_body.strip():
+                converter = self._arg_converter
+                if converter is not None:
+                    try:
+                        args_json = converter(raw_body, False)
+                    except (json.JSONDecodeError, ValueError, TypeError):
+                        logger.debug(
+                            "arg converter failed (extract): %s", raw_body[:80]
+                        )
+                        args_json = self._extract_args_json(raw_body, name)
+                else:
+                    args_json = self._extract_args_json(raw_body, name)
+            else:
+                args_json = "{}"
+
+            if name and self._is_valid_tool_name(name):
+                self._ensure_tool_id(slot, name)
+                args_json = self._fix_arg_types(args_json, name)
+                tool_calls.append(
+                    ToolCall(
+                        id=slot.id,
+                        function=FunctionCall(name=name, arguments=args_json),
+                    )
+                )
+
+        content_str = "".join(content_parts)
+        content = self._strip_content_whitespace(content_str, len(tool_calls) > 0)
+
+        return ExtractedToolCallInformation(
+            tools_called=len(tool_calls) > 0,
+            tool_calls=tool_calls,
+            content=content,
+        )
+
+    @staticmethod
+    def _extract_args_value(parsed: dict) -> str | None:
+        for key in ("arguments", "parameters"):
+            if key in parsed:
+                val = parsed[key]
+                if isinstance(val, str):
+                    return val
+                return json.dumps(val, ensure_ascii=False)
+        return None
+
+    def _extract_name_and_args(
+        self,
+        raw_body: str,
+    ) -> tuple[str, str]:
+        raw_body = raw_body.strip()
+        try:
+            parsed = json.loads(raw_body)
+        except json.JSONDecodeError:
+            return "", raw_body
+
+        if not isinstance(parsed, dict):
+            return "", raw_body
+
+        name = parsed.get("name", "")
+        args = self._extract_args_value(parsed)
+        if args is not None:
+            return name, args
+
+        without_name = {k: v for k, v in parsed.items() if k != "name"}
+        return name, json.dumps(without_name, ensure_ascii=False)
+
+    def _extract_args_json(self, raw_args: str, func_name: str) -> str:
+        if not raw_args.strip():
+            return "{}"
+        _, args = self._extract_name_and_args(raw_args)
+        return args

--- a/vllm/parser/engine/parser_engine_config.py
+++ b/vllm/parser/engine/parser_engine_config.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Declarative configuration for model tool-call and reasoning formats.
+
+Each model format is described by a :class:`ParserEngineConfig` that specifies:
+
+* **terminals** – literal strings or regex patterns that delimit the format
+  (e.g. ``<tool_call>``, ``</think>``).
+* **token_id_terminals** – terminals that should be matched by token ID
+  rather than (or in addition to) text.
+* **transitions** – a state machine mapping
+  ``(state, terminal) → (new_state, events_to_emit)`` that drives semantic
+  event generation during streaming.
+* **content_events** – what :class:`EventType` to emit for plain content
+  (non-terminal text) in each state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from functools import cached_property
+
+from vllm.parser.engine.events import EventType
+
+STRUCTURAL_DROP_TOKENS: frozenset[str] = frozenset(
+    {
+        "<eos>",
+        "<bos>",
+        "<pad>",
+        "<unk>",
+        "<mask>",
+    }
+)
+
+
+class ParserState(Enum):
+    CONTENT = auto()
+    REASONING = auto()
+    TOOL_PREAMBLE = auto()
+    TOOL_NAME = auto()
+    TOOL_ARGS = auto()
+    TOOL_BETWEEN = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class Transition:
+    next_state: ParserState
+    events: tuple[EventType, ...] = field(default_factory=tuple)
+    skip_in_token_id_mode: bool = False
+
+
+@dataclass(frozen=True)
+class ParserEngineConfig:
+    """Declarative description of a model's tool-call / reasoning format.
+
+    The engine feeds terminals from the incremental lexer into the
+    transition table and emits the corresponding semantic events.
+    Content tokens (text between terminals) are classified by the
+    current state via ``content_events``.
+    """
+
+    name: str
+
+    terminals: dict[str, str] = field(default_factory=dict)
+
+    token_id_terminals: dict[str, str] = field(default_factory=dict)
+
+    transitions: dict[tuple[ParserState, str], Transition] = field(
+        default_factory=dict,
+    )
+
+    content_events: dict[ParserState, EventType] = field(
+        default_factory=lambda: {
+            ParserState.CONTENT: EventType.TEXT_CHUNK,
+            ParserState.REASONING: EventType.REASONING_CHUNK,
+            ParserState.TOOL_NAME: EventType.TOOL_NAME,
+            ParserState.TOOL_ARGS: EventType.ARG_VALUE_CHUNK,
+        },
+    )
+
+    initial_state: ParserState = ParserState.CONTENT
+
+    arg_converter: Callable[[str, bool], str] | None = None
+
+    stream_arg_deltas: bool = True
+
+    tool_args_json: bool = True
+
+    arg_structural_chars: frozenset[str] | None = None
+
+    # Prevents trailing-whitespace accumulation across multi-turn conversations.
+    strip_trailing_reasoning_whitespace: bool = True
+
+    # Drop content that is entirely whitespace when tool calls follow.
+    drop_whitespace_only_content_before_tools: bool = True
+
+    # .strip() content text when tool calls are present.
+    strip_content_whitespace_with_tools: bool = True
+
+    # Reject tool calls whose names are absent from the request tools.
+    validate_tool_names: bool = False
+
+    drop_tokens: frozenset[str] = field(default_factory=frozenset)
+
+    @cached_property
+    def terminal_defs(self):
+        from vllm.parser.engine.incremental_lexer import terminals_from_literals
+
+        return terminals_from_literals(self.terminals)
+
+    @cached_property
+    def lexer_shape(self):
+        from vllm.parser.engine.incremental_lexer import LexerShape
+
+        return LexerShape(self.terminal_defs)

--- a/vllm/parser/engine/registered_adapters.py
+++ b/vllm/parser/engine/registered_adapters.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Concrete adapter classes for parser engines present in this tree."""
+
+from vllm.parser.engine.adapters import make_adapters
+from vllm.parser.qwen3 import Qwen3Parser
+
+(
+    Qwen3ParserReasoningAdapter,
+    Qwen3ParserToolAdapter,
+) = make_adapters(Qwen3Parser)
+
+__all__ = [
+    "Qwen3ParserReasoningAdapter",
+    "Qwen3ParserToolAdapter",
+]

--- a/vllm/parser/engine/streaming_parser_engine.py
+++ b/vllm/parser/engine/streaming_parser_engine.py
@@ -1,0 +1,425 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Streaming parser engine that orchestrates token ID scanning,
+incremental lexing, and state-machine-driven semantic event emission."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from vllm.parser.engine.events import EventType, SemanticEvent
+from vllm.parser.engine.incremental_lexer import (
+    CONTENT_TERMINAL,
+    IncrementalLexer,
+    LexToken,
+)
+from vllm.parser.engine.parser_engine_config import (
+    STRUCTURAL_DROP_TOKENS,
+    ParserEngineConfig,
+    ParserState,
+    Transition,
+)
+from vllm.parser.engine.token_id_scanner import (
+    LexerInput,
+    PreLexedTerminal,
+    TextChunk,
+    TokenIDScanner,
+)
+
+
+class StreamingParserEngine:
+    """Consumes ``(delta_text, delta_token_ids)`` pairs and produces a
+    stream of :class:`SemanticEvent` instances.
+
+    This is the main entry point for streaming parsing.
+    Create one per request (it is stateful).
+
+    The pipeline is::
+
+        delta_text + delta_token_ids
+            → TokenIDScanner  (special token pre-lexing)
+            → IncrementalLexer  (text → terminal tokens with prefix buffering)
+            → State Machine  (terminal → semantic events)
+            → list[SemanticEvent]
+
+    Usage::
+
+        engine = StreamingParserEngine(config, tokenizer)
+        for each streaming delta:
+            events = engine.feed(delta_text, delta_token_ids)
+            # convert events to DeltaMessage
+    """
+
+    def __init__(
+        self,
+        config: ParserEngineConfig,
+        tokenizer,
+        initial_state: ParserState | None = None,
+        vocab: dict[str, int] | None = None,
+    ) -> None:
+        self.config = config
+
+        resolved_token_ids: dict[int, str] = {}
+        drop_token_ids: set[int] = set()
+        if tokenizer is not None:
+            if vocab is None:
+                vocab = tokenizer.get_vocab()
+            if config.token_id_terminals:
+                for terminal_name, token_text in config.token_id_terminals.items():
+                    tid = vocab.get(token_text)
+                    if tid is not None and self._tokenizer_emits_single_token(
+                        tokenizer,
+                        token_text,
+                        tid,
+                    ):
+                        resolved_token_ids[tid] = terminal_name
+            all_drop = config.drop_tokens | STRUCTURAL_DROP_TOKENS
+            for token_text in all_drop:
+                tid = vocab.get(token_text)
+                if tid is not None:
+                    drop_token_ids.add(tid)
+            for attr in ("eos_token_id", "bos_token_id", "pad_token_id"):
+                tid = getattr(tokenizer, attr, None)
+                if tid is not None:
+                    drop_token_ids.add(tid)
+
+        self._resolved_token_ids = resolved_token_ids
+        self._drop_token_ids = drop_token_ids
+
+        self._scanner = TokenIDScanner(
+            resolved_token_ids,
+            tokenizer,
+            drop_token_ids,
+        )
+
+        self._token_id_terminal_names: frozenset[str] = frozenset(
+            resolved_token_ids.values()
+        )
+
+        self._lexer = IncrementalLexer(
+            config.lexer_shape, content_terminal=CONTENT_TERMINAL
+        )
+
+        self._tool_terminals: frozenset[str] = frozenset(
+            terminal
+            for (state, terminal), tr in config.transitions.items()
+            if tr.next_state in self._TOOL_STATES or state in self._TOOL_STATES
+        )
+
+        self.skip_tool_parsing = False
+        self.reset(initial_state=initial_state)
+
+    @staticmethod
+    def _tokenizer_emits_single_token(tokenizer, text: str, token_id: int) -> bool:
+        encode = getattr(tokenizer, "encode", None)
+        if encode is None:
+            return True
+        try:
+            token_ids = encode(text, add_special_tokens=False)
+        except TypeError:
+            token_ids = encode(text)
+        except Exception:
+            return True
+        return list(token_ids) == [token_id]
+
+    def _reset_args_state(self) -> None:
+        self._args_buffer: str = ""
+        self._args_safe_end: int = 0
+        self._args_brace_depth: int = 0
+        self._args_in_string: bool = False
+        self._args_escape_next: bool = False
+
+    def reset(self, initial_state: ParserState | None = None) -> None:
+        """Reset mutable state for reuse across requests.
+
+        Preserves cached immutable structures (compiled terminals,
+        resolved token IDs, lexer shape, token text cache) to avoid
+        redundant initialization work.
+        """
+        self.state = (
+            initial_state if initial_state is not None else self.config.initial_state
+        )
+        self.tool_index = -1
+        self._ever_had_token_ids = False
+        # DO NOT reset skip_tool_parsing here — callers set it before
+        # calling methods that trigger reset() (e.g. extract_reasoning),
+        # and clearing it silently breaks non-streaming tool-call-as-
+        # implicit-reasoning-end (content returns None).
+        self._scanner.reset()
+        self._lexer.reset()
+        self._reset_args_state()
+
+    def feed(
+        self,
+        delta_text: str,
+        delta_token_ids: Sequence[int],
+    ) -> list[SemanticEvent]:
+        if delta_token_ids:
+            self._ever_had_token_ids = True
+
+        # Fast path: skip scanner and lexer when the delta is plain
+        # content with no special tokens and no terminal-starting chars.
+        if (
+            delta_text
+            and not self._lexer.buffer
+            and not self._scanner._deferred_terminals
+            and self._lexer._literal_first_chars.isdisjoint(delta_text)
+        ):
+            has_special = False
+            for tid in delta_token_ids:
+                if tid in self._resolved_token_ids or tid in self._drop_token_ids:
+                    has_special = True
+                    break
+            if not has_special:
+                return self._emit_for_state(delta_text)
+
+        scanner_items = self._scanner.scan(delta_text, delta_token_ids)
+
+        if len(scanner_items) == 1 and isinstance(scanner_items[0], TextChunk):
+            lex_tokens = self._lexer.feed(scanner_items[0].text)
+            if len(lex_tokens) == 1 and lex_tokens[0].terminal == CONTENT_TERMINAL:
+                text = lex_tokens[0].value
+                return self._emit_for_state(text)
+            return self._process_lex_tokens(lex_tokens)
+
+        return self._process_scanner_items(scanner_items)
+
+    def _process_scanner_items(
+        self, items: Sequence[LexerInput]
+    ) -> list[SemanticEvent]:
+        events: list[SemanticEvent] = []
+        for item in items:
+            if isinstance(item, PreLexedTerminal):
+                events.extend(self._process_lex_tokens(self._lexer.flush()))
+                events.extend(self._on_terminal(item.terminal, item.text))
+            elif isinstance(item, TextChunk):
+                events.extend(self._process_lex_tokens(self._lexer.feed(item.text)))
+        return events
+
+    def finish(self) -> list[SemanticEvent]:
+        events = self._process_scanner_items(self._scanner.flush_pending())
+
+        events.extend(self._process_lex_tokens(self._lexer.flush()))
+
+        if self._args_buffer:
+            events.append(
+                SemanticEvent(
+                    EventType.ARG_VALUE_CHUNK,
+                    value=self._args_buffer,
+                    tool_index=self.tool_index,
+                )
+            )
+            self._args_buffer = ""
+            self._args_safe_end = 0
+
+        if self.state in (
+            ParserState.TOOL_PREAMBLE,
+            ParserState.TOOL_ARGS,
+            ParserState.TOOL_NAME,
+            ParserState.TOOL_BETWEEN,
+        ):
+            if self.tool_index >= 0:
+                events.append(
+                    SemanticEvent(
+                        EventType.TOOL_CALL_END,
+                        tool_index=self.tool_index,
+                    )
+                )
+            self.state = ParserState.CONTENT
+        elif self.state == ParserState.REASONING:
+            events.append(
+                SemanticEvent(EventType.REASONING_END, tool_index=self.tool_index)
+            )
+            self.state = ParserState.CONTENT
+
+        return events
+
+    def parse_complete(self, text: str) -> list[SemanticEvent]:
+        token_ids: list[int] = []
+        events = self.feed(text, token_ids)
+        events.extend(self.finish())
+        return events
+
+    def _process_lex_tokens(self, tokens: list[LexToken]) -> list[SemanticEvent]:
+        events: list[SemanticEvent] = []
+        strict = self._token_id_terminal_names if self._ever_had_token_ids else None
+        for tok in tokens:
+            if tok.terminal == CONTENT_TERMINAL or (strict and tok.terminal in strict):
+                events.extend(self._on_content(tok.value))
+            else:
+                events.extend(self._on_terminal(tok.terminal, tok.value))
+        return events
+
+    _TOOL_STATES = frozenset(
+        {
+            ParserState.TOOL_PREAMBLE,
+            ParserState.TOOL_NAME,
+            ParserState.TOOL_ARGS,
+            ParserState.TOOL_BETWEEN,
+        }
+    )
+
+    def _on_terminal(self, terminal: str, value: str) -> list[SemanticEvent]:
+        key = (self.state, terminal)
+        transition = self.config.transitions.get(key)
+
+        if transition is None:
+            return self._emit_for_state(value)
+
+        if self.skip_tool_parsing and terminal in self._tool_terminals:
+            if EventType.REASONING_END in transition.events:
+                self.state = ParserState.CONTENT
+                return [
+                    SemanticEvent(
+                        EventType.REASONING_END,
+                        value=value,
+                        tool_index=self.tool_index,
+                    ),
+                    SemanticEvent(
+                        EventType.TEXT_CHUNK,
+                        value=value,
+                        tool_index=self.tool_index,
+                    ),
+                ]
+            content_type = self.config.content_events.get(self.state)
+            if content_type is not None:
+                return [
+                    SemanticEvent(content_type, value=value, tool_index=self.tool_index)
+                ]
+            return []
+
+        if transition.skip_in_token_id_mode and self._ever_had_token_ids:
+            return self._emit_for_state(value)
+
+        return self._apply_transition(transition, value)
+
+    def _emit_for_state(self, text: str) -> list[SemanticEvent]:
+        if self.state == ParserState.TOOL_ARGS:
+            if self.config.tool_args_json:
+                return self._feed_args_text(text)
+            return [
+                SemanticEvent(
+                    EventType.ARG_VALUE_CHUNK,
+                    value=text,
+                    tool_index=self.tool_index,
+                )
+            ]
+        content_type = self.config.content_events.get(self.state)
+        if content_type is not None:
+            return [SemanticEvent(content_type, value=text, tool_index=self.tool_index)]
+        return []
+
+    def _on_content(self, text: str) -> list[SemanticEvent]:
+        if not text:
+            return []
+        return self._emit_for_state(text)
+
+    def _apply_transition(
+        self,
+        transition: Transition,
+        value: str,
+    ) -> list[SemanticEvent]:
+        events: list[SemanticEvent] = []
+
+        if (
+            self.state == ParserState.TOOL_ARGS
+            and transition.next_state != ParserState.TOOL_ARGS
+            and self._args_buffer
+        ):
+            events.append(
+                SemanticEvent(
+                    EventType.ARG_VALUE_CHUNK,
+                    value=self._args_buffer,
+                    tool_index=self.tool_index,
+                )
+            )
+            self._args_buffer = ""
+
+        self.state = transition.next_state
+
+        for event_type in transition.events:
+            if event_type == EventType.TOOL_CALL_START:
+                self.tool_index += 1
+            events.append(
+                SemanticEvent(
+                    event_type,
+                    value=value,
+                    tool_index=self.tool_index,
+                )
+            )
+
+        if self.state == ParserState.TOOL_ARGS:
+            self._args_brace_depth = 0
+            self._args_in_string = False
+            self._args_escape_next = False
+            self._args_safe_end = 0
+
+        return events
+
+    def _feed_args_text(self, text: str) -> list[SemanticEvent]:
+        """Feed text into the JSON argument streaming buffer.
+
+        Streams argument characters incrementally while holding back
+        closing braces/brackets that might change as more input arrives.
+        """
+        events: list[SemanticEvent] = []
+        for ch in text:
+            result = self._feed_args_char(ch)
+            events.extend(result)
+        return events
+
+    def _feed_args_char(self, ch: str) -> list[SemanticEvent]:
+        self._args_buffer += ch
+
+        if self._args_escape_next:
+            self._args_escape_next = False
+            self._args_safe_end = len(self._args_buffer)
+            return self._flush_safe_args()
+
+        if self._args_in_string:
+            if ch == "\\":
+                self._args_escape_next = True
+            elif ch == '"':
+                self._args_in_string = False
+            self._args_safe_end = len(self._args_buffer)
+            return self._flush_safe_args()
+
+        if ch == '"':
+            self._args_in_string = True
+            self._args_safe_end = len(self._args_buffer)
+            return self._flush_safe_args()
+
+        if ch in ("{", "["):
+            self._args_brace_depth += 1
+            self._args_safe_end = len(self._args_buffer)
+            return self._flush_safe_args()
+
+        if ch in ("}", "]"):
+            if self._args_brace_depth > 0:
+                self._args_brace_depth -= 1
+            if self._args_brace_depth == 0:
+                return []
+            self._args_safe_end = len(self._args_buffer)
+            return self._flush_safe_args()
+
+        self._args_safe_end = len(self._args_buffer)
+        return self._flush_safe_args()
+
+    def _flush_safe_args(self) -> list[SemanticEvent]:
+        """Emit buffered argument characters up to the safe-end watermark.
+
+        Top-level closing braces are held back (safe_end not advanced)
+        until confirmed safe by a subsequent character or finish().
+        """
+        if self._args_safe_end == 0:
+            return []
+        to_emit = self._args_buffer[: self._args_safe_end]
+        self._args_buffer = self._args_buffer[self._args_safe_end :]
+        self._args_safe_end = 0
+        return [
+            SemanticEvent(
+                EventType.ARG_VALUE_CHUNK,
+                value=to_emit,
+                tool_index=self.tool_index,
+            )
+        ]

--- a/vllm/parser/engine/token_id_scanner.py
+++ b/vllm/parser/engine/token_id_scanner.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Scan delta token IDs for special tokens and split the stream into
+pre-lexed terminals and plain text chunks."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class TextChunk:
+    text: str
+
+
+@dataclass(slots=True)
+class PreLexedTerminal:
+    terminal: str
+    token_id: int
+    text: str
+
+
+LexerInput = TextChunk | PreLexedTerminal
+
+
+class TokenIDScanner:
+    """Maps special token IDs in the delta to terminals.
+
+    Before text-based lexing happens, the scanner checks each token ID
+    in the delta against a mapping of ``{token_id: terminal_name}``.
+    Matched tokens are emitted as :class:`PreLexedTerminal` items;
+    everything else is grouped into :class:`TextChunk` items for the
+    incremental lexer to process.
+
+    When a terminal's text is not yet in ``delta_text`` (held back by
+    the detokenizer), the terminal is deferred until the text arrives
+    in a subsequent delta.
+    """
+
+    def __init__(
+        self,
+        token_id_to_terminal: dict[int, str],
+        tokenizer,
+        drop_token_ids: set[int] | None = None,
+    ) -> None:
+        self.token_id_to_terminal = token_id_to_terminal
+        self.tokenizer = tokenizer
+        self._token_text_cache: dict[int, str] = {}
+        self._drop_token_ids = drop_token_ids or set()
+        self._deferred_terminals: list[PreLexedTerminal] = []
+        self._deferred_post_text: str = ""
+
+    def reset(self) -> None:
+        """Clear mutable state for reuse. Preserves the token text cache."""
+        self._deferred_terminals.clear()
+        self._deferred_post_text = ""
+
+    def _decode_token(self, token_id: int) -> str:
+        if token_id not in self._token_text_cache:
+            self._token_text_cache[token_id] = self.tokenizer.decode([token_id])
+        return self._token_text_cache[token_id]
+
+    _EMPTY: tuple[LexerInput, ...] = ()
+
+    def scan(
+        self,
+        delta_text: str,
+        delta_token_ids: Sequence[int],
+    ) -> Sequence[LexerInput]:
+        prefix_items: list[LexerInput] = []
+        effective_text = delta_text
+
+        if self._deferred_terminals:
+            prefix_items, effective_text = self._resolve_deferred(delta_text)
+
+        if not self.token_id_to_terminal and not self._drop_token_ids:
+            if effective_text:
+                prefix_items.append(TextChunk(effective_text))
+            return prefix_items
+
+        has_special = False
+        has_drop = False
+        token_id_to_terminal = self.token_id_to_terminal
+        drop_token_ids = self._drop_token_ids
+        for tid in delta_token_ids:
+            if tid in token_id_to_terminal:
+                has_special = True
+            if tid in drop_token_ids:
+                has_drop = True
+
+        if not has_special and not has_drop:
+            if effective_text:
+                if not prefix_items:
+                    return [TextChunk(effective_text)]
+                prefix_items.append(TextChunk(effective_text))
+            return prefix_items or self._EMPTY
+
+        token_texts = [self._decode_token(tid) for tid in delta_token_ids]
+
+        results: list[LexerInput] = []
+        text_accum: list[str] = []
+
+        for idx, tid in enumerate(delta_token_ids):
+            if tid in self._drop_token_ids:
+                continue
+            terminal = self.token_id_to_terminal.get(tid)
+            if terminal is not None:
+                if text_accum:
+                    joined = "".join(text_accum)
+                    if joined:
+                        results.append(TextChunk(joined))
+                    text_accum.clear()
+                results.append(PreLexedTerminal(terminal, tid, token_texts[idx]))
+            else:
+                text_accum.append(token_texts[idx])
+
+        if text_accum:
+            joined = "".join(text_accum)
+            if joined:
+                results.append(TextChunk(joined))
+
+        if effective_text:
+            if has_drop:
+                clean_delta = effective_text
+                for idx, tid in enumerate(delta_token_ids):
+                    if tid in self._drop_token_ids:
+                        dropped = token_texts[idx]
+                        pos = clean_delta.find(dropped)
+                        if pos >= 0:
+                            clean_delta = (
+                                clean_delta[:pos] + clean_delta[pos + len(dropped) :]
+                            )
+                if clean_delta:
+                    if results:
+                        results = self._recover_holdback_text(clean_delta, results)
+                    else:
+                        results = [TextChunk(clean_delta)]
+            else:
+                results = self._recover_holdback_text(effective_text, results)
+        else:
+            # No detokenizer text to validate against — individually-decoded
+            # TextChunks are unreliable (context-dependent decoding).
+            # Defer PreLexedTerminals so the state machine doesn't
+            # transition before the preceding text has arrived.  The
+            # deferred terminals will be resolved against the actual
+            # delta_text in a subsequent scan() or flushed by finish().
+            for r in results:
+                if isinstance(r, PreLexedTerminal):
+                    self._deferred_terminals.append(r)
+            results = []
+
+        return prefix_items + results
+
+    def flush_pending(self) -> list[LexerInput]:
+        if not self._deferred_terminals and not self._deferred_post_text:
+            return []
+        results: list[LexerInput] = []
+        if self._deferred_post_text:
+            results.append(TextChunk(self._deferred_post_text))
+            self._deferred_post_text = ""
+        results.extend(self._deferred_terminals)
+        self._deferred_terminals.clear()
+        return results
+
+    def _resolve_deferred(
+        self,
+        delta_text: str,
+    ) -> tuple[list[LexerInput], str]:
+        """Resolve deferred terminals against new delta_text.
+
+        When a previous ``scan()`` deferred a terminal (its text hadn't
+        arrived yet), the next delta's text should contain that terminal's
+        text.  Split delta_text at the terminal boundary: text before
+        belongs to the previous parser state, the terminal triggers the
+        state transition, and text after belongs to the new state.
+
+        Returns ``(prefix_items, remaining_text)`` where prefix_items
+        are the resolved deferred terminals (with any preceding text)
+        and remaining_text is the unconsumed portion of delta_text that
+        should be scanned with the current delta's token IDs.
+        """
+        deferred = self._deferred_terminals
+        self._deferred_terminals = []
+
+        results: list[LexerInput] = []
+        remaining = delta_text
+
+        if self._deferred_post_text:
+            remaining = self._deferred_post_text + remaining
+            self._deferred_post_text = ""
+
+        # Duplicate-text deferred terminals resolve left-to-right via
+        # find(); correct when each terminal text appears once in sequence.
+        for terminal in deferred:
+            pos = remaining.find(terminal.text)
+            if pos > 0:
+                results.append(TextChunk(remaining[:pos]))
+                results.append(terminal)
+                remaining = remaining[pos + len(terminal.text) :]
+            elif pos == 0:
+                results.append(terminal)
+                remaining = remaining[len(terminal.text) :]
+            else:
+                # Accumulate text until terminal text arrives —
+                # only the terminal provides a reliable split point.
+                if remaining:
+                    self._deferred_post_text += remaining
+                    remaining = ""
+                self._deferred_terminals.append(terminal)
+
+        return results, remaining
+
+    def _recover_holdback_text(
+        self,
+        delta_text: str,
+        results: list[LexerInput],
+    ) -> list[LexerInput]:
+        """Recover detokenizer hold-back text not in delta_token_ids.
+
+        The detokenizer may flush previously held-back text in
+        ``delta_text`` that has no corresponding token ID in
+        ``delta_token_ids``.  This hold-back text always appears as a
+        prefix of ``delta_text``.
+        """
+        if not results:
+            return [TextChunk(delta_text)]
+
+        reconstructed = self._join_decoded_text(results)
+
+        if not reconstructed:
+            return [TextChunk(delta_text)] + results
+
+        pos = delta_text.find(reconstructed)
+        if pos > 0:
+            return [TextChunk(delta_text[:pos])] + results
+        if pos == 0:
+            return results
+
+        # Fallback: SentencePiece context-dependent decoding mismatch.
+        # Rebuild from delta_text using PreLexedTerminals as split anchors.
+        return self._rebuild_from_anchors(delta_text, results)
+
+    def _join_decoded_text(self, results: list[LexerInput]) -> str:
+        """Join TextChunk and PreLexedTerminal text into one string."""
+        parts: list[str] = []
+        for item in results:
+            if isinstance(item, (TextChunk, PreLexedTerminal)):
+                parts.append(item.text)
+        return "".join(parts)
+
+    def _rebuild_from_anchors(
+        self,
+        delta_text: str,
+        results: list[LexerInput],
+    ) -> list[LexerInput]:
+        """Rebuild results from delta_text using terminals as anchors.
+
+        When context-dependent decoding creates a mismatch between
+        individually-decoded tokens and delta_text, use
+        PreLexedTerminals as split points and reallocate text from
+        delta_text.  If a terminal's text is not found in delta_text,
+        it is deferred to the next scan() call.
+
+        Anchors are resolved right-to-left with ``rfind`` so that each
+        anchor binds to the *rightmost* available occurrence of its
+        text.  This prevents earlier literal lookalikes (e.g. a user
+        mentioning ``<tool_call>`` in prose) from stealing the position
+        of a real special-token anchor that appears later.
+
+        If the same anchor text appears multiple times as real special
+        tokens (not prose), the rightmost-first binding could misalign.
+        In practice this doesn't happen: each special token ID maps to
+        a distinct PreLexedTerminal, and duplicates in prose are resolved
+        by the token-ID filtering layer above.
+        """
+        anchors = [item for item in results if isinstance(item, PreLexedTerminal)]
+        if not anchors:
+            return [TextChunk(delta_text)]
+
+        # Resolve positions right-to-left: each anchor gets the
+        # rightmost occurrence that is still before the next anchor.
+        positions: list[int] = [-1] * len(anchors)
+        search_end = len(delta_text)
+        for i in range(len(anchors) - 1, -1, -1):
+            pos = delta_text.rfind(anchors[i].text, 0, search_end)
+            if pos >= 0:
+                positions[i] = pos
+                search_end = pos
+
+        # Build results left-to-right using the resolved positions.
+        new_results: list[LexerInput] = []
+        consumed = 0
+        for i, anchor in enumerate(anchors):
+            pos = positions[i]
+            if pos >= consumed:
+                if pos > consumed:
+                    new_results.append(TextChunk(delta_text[consumed:pos]))
+                new_results.append(anchor)
+                consumed = pos + len(anchor.text)
+            else:
+                has_later_valid = any(p >= 0 for p in positions[i + 1 :])
+                if not has_later_valid and consumed < len(delta_text):
+                    self._deferred_post_text += delta_text[consumed:]
+                    consumed = len(delta_text)
+                self._deferred_terminals.append(anchor)
+        if consumed < len(delta_text):
+            new_results.append(TextChunk(delta_text[consumed:]))
+        return new_results

--- a/vllm/parser/qwen3.py
+++ b/vllm/parser/qwen3.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen3 parser for tool calls and reasoning.
+
+Qwen3 XML tool call format::
+
+    <tool_call>
+    <function=func_name>
+    <parameter=key>value</parameter>
+    </function>
+    </tool_call>
+
+The argument body consists of ``<parameter=NAME>VALUE</parameter>`` tags.
+The ``_qwen3_arg_converter`` parses these into a JSON object.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+from typing import TYPE_CHECKING
+
+import regex as re
+
+from vllm.parser.engine.events import EventType
+from vllm.parser.engine.parser_engine import ParserEngine
+from vllm.parser.engine.parser_engine_config import (
+    ParserEngineConfig,
+    ParserState,
+    Transition,
+)
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.protocol import (
+        ChatCompletionRequest,
+        ResponsesRequest,
+    )
+    from vllm.tokenizers import TokenizerLike
+    from vllm.entrypoints.openai.tool_parsers.utils import Tool
+
+THINK_START = "<think>"
+THINK_END = "</think>"
+TOOL_CALL_START = "<tool_call>"
+TOOL_CALL_END = "</tool_call>"
+FUNC_PREFIX = "<function="
+FUNC_END = "</function>"
+PARAM_START = "<parameter="
+PARAM_END = "</parameter>"
+
+_PARAM_RE = re.compile(
+    r"<\s*parameter\s*=\s*([^>]*)>"
+    r"(.*?)"
+    r"(?:<\s*/\s*parameter\s*>|(?=<\s*parameter\s*=))",
+    re.DOTALL,
+)
+_PARTIAL_PARAM_RE = re.compile(r"<\s*parameter\s*=\s*([^>]+)>(.*)$", re.DOTALL)
+
+
+def _qwen3_arg_converter(raw_args: str, partial: bool) -> str:
+    params: dict[str, object] = {}
+
+    for match in _PARAM_RE.finditer(raw_args):
+        name = match.group(1)
+        value = match.group(2)
+        params[name] = value.strip()
+
+    if partial:
+        remaining = _PARAM_RE.sub("", raw_args)
+        m = _PARTIAL_PARAM_RE.search(remaining)
+        if m:
+            name = m.group(1)
+            value = m.group(2)
+            if name:
+                params[name] = value.strip()
+
+    return json.dumps(params, ensure_ascii=False)
+
+
+@functools.cache
+def qwen3_config(
+    thinking: bool = True,
+    *,
+    name: str = "qwen3",
+    think_start: str = THINK_START,
+    think_end: str = THINK_END,
+    tool_start: str = TOOL_CALL_START,
+    tool_end: str = TOOL_CALL_END,
+) -> ParserEngineConfig:
+    return ParserEngineConfig(
+        name=name,
+        initial_state=ParserState.REASONING if thinking else ParserState.CONTENT,
+        terminals={
+            # Reasoning terminals
+            "THINK_START": think_start,
+            "THINK_END": think_end,
+            # Tool call terminals
+            "TOOL_START": tool_start,
+            "TOOL_END": tool_end,
+            "FUNC_PREFIX": FUNC_PREFIX,
+            "FUNC_END": FUNC_END,
+            "PARAM_START": PARAM_START,
+            "PARAM_END": PARAM_END,
+            "CLOSE_ANGLE": ">",
+        },
+        token_id_terminals={
+            "THINK_START": think_start,
+            "THINK_END": think_end,
+            "TOOL_START": tool_start,
+            "TOOL_END": tool_end,
+        },
+        transitions={
+            # -- Reasoning transitions --
+            (ParserState.REASONING, "THINK_START"): Transition(
+                ParserState.REASONING,
+                (),
+            ),
+            (ParserState.REASONING, "THINK_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.REASONING_END,),
+            ),
+            # Absorb duplicate </think> — model may emit it after
+            # already transitioning to CONTENT; drop it silently.
+            (ParserState.CONTENT, "THINK_END"): Transition(
+                ParserState.CONTENT,
+                (),
+            ),
+            # Tool call directly from reasoning (implicit end)
+            (ParserState.REASONING, "TOOL_START"): Transition(
+                ParserState.TOOL_PREAMBLE,
+                (EventType.REASONING_END, EventType.TOOL_CALL_START),
+            ),
+            # -- Tool call transitions --
+            (ParserState.CONTENT, "TOOL_START"): Transition(
+                ParserState.TOOL_PREAMBLE,
+                (EventType.REASONING_END, EventType.TOOL_CALL_START),
+            ),
+            # Fallback: <function= without a preceding <tool_call>
+            (ParserState.CONTENT, "FUNC_PREFIX"): Transition(
+                ParserState.TOOL_NAME,
+                (EventType.TOOL_CALL_START,),
+            ),
+            (ParserState.TOOL_PREAMBLE, "TOOL_END"): Transition(
+                ParserState.CONTENT,
+                (EventType.TOOL_CALL_END,),
+            ),
+            (ParserState.TOOL_PREAMBLE, "FUNC_PREFIX"): Transition(
+                ParserState.TOOL_NAME,
+                (),
+            ),
+            (ParserState.TOOL_NAME, "CLOSE_ANGLE"): Transition(
+                ParserState.TOOL_ARGS,
+                (),
+            ),
+            # Malformed: </function> while still in TOOL_NAME (no closing >)
+            (ParserState.TOOL_NAME, "FUNC_END"): Transition(
+                ParserState.TOOL_BETWEEN,
+                (EventType.TOOL_CALL_END,),
+            ),
+            (ParserState.TOOL_ARGS, "FUNC_END"): Transition(
+                ParserState.TOOL_BETWEEN,
+                (EventType.TOOL_CALL_END,),
+            ),
+            (ParserState.TOOL_ARGS, "PARAM_START"): Transition(
+                ParserState.TOOL_ARGS,
+                (EventType.ARG_VALUE_CHUNK,),
+            ),
+            (ParserState.TOOL_ARGS, "PARAM_END"): Transition(
+                ParserState.TOOL_ARGS,
+                (EventType.ARG_VALUE_CHUNK,),
+            ),
+            (ParserState.TOOL_BETWEEN, "TOOL_END"): Transition(
+                ParserState.CONTENT,
+                (),
+            ),
+            # Consecutive tool call without closing </tool_call>
+            (ParserState.TOOL_BETWEEN, "TOOL_START"): Transition(
+                ParserState.TOOL_PREAMBLE,
+                (EventType.TOOL_CALL_START,),
+            ),
+            (ParserState.TOOL_BETWEEN, "FUNC_PREFIX"): Transition(
+                ParserState.TOOL_NAME,
+                (EventType.TOOL_CALL_START,),
+            ),
+        },
+        arg_converter=_qwen3_arg_converter,
+        stream_arg_deltas=True,
+        strip_trailing_reasoning_whitespace=False,
+        tool_args_json=False,
+    )
+
+
+class Qwen3Parser(ParserEngine):
+    """Qwen3 parser: ``<think>``/``</think>`` reasoning +
+    ``<tool_call>`` XML tool calls in a single engine.
+
+    - ``<tool_call>`` as implicit reasoning end
+    - Unpaired ``<tool_call>`` token ID detection for ``is_reasoning_end``
+
+    Subclasses that share the grammar but differ only in the four wrapper
+    token strings (reasoning + tool-call) override the class attributes
+    below; everything else is inherited unchanged.
+    """
+
+    CONFIG_NAME = "qwen3"
+    THINK_START = THINK_START
+    THINK_END = THINK_END
+    TOOL_START = TOOL_CALL_START
+    TOOL_END = TOOL_CALL_END
+
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[Tool] | None = None,
+        **kwargs,
+    ) -> None:
+        chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
+        self.thinking_enabled = chat_kwargs.get("enable_thinking", True)
+        kwargs.setdefault(
+            "parser_engine_config",
+            qwen3_config(
+                thinking=self.thinking_enabled,
+                name=self.CONFIG_NAME,
+                think_start=self.THINK_START,
+                think_end=self.THINK_END,
+                tool_start=self.TOOL_START,
+                tool_end=self.TOOL_END,
+            ),
+        )
+        super().__init__(
+            tokenizer,
+            tools,
+            **kwargs,
+        )
+        vocab = self.vocab
+        self._tool_call_token_id: int | None = vocab.get(self.TOOL_START)
+        self._tool_call_end_token_id: int | None = vocab.get(self.TOOL_END)
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> tuple[str | None, str | None]:
+        if not self.thinking_enabled:
+            return None, model_output
+        return super().extract_reasoning(model_output, request)
+
+    def is_reasoning_end(self, input_ids: list[int]) -> bool:
+        if super().is_reasoning_end(input_ids):
+            return True
+        tool_call_id = self._tool_call_token_id
+        tool_call_end_id = self._tool_call_end_token_id
+        reasoning_start_id = self._reasoning_start_token_id
+        if tool_call_id is not None:
+            for i in range(len(input_ids) - 1, -1, -1):
+                if (
+                    reasoning_start_id is not None
+                    and input_ids[i] == reasoning_start_id
+                ):
+                    return False
+                if input_ids[i] == tool_call_id:
+                    if tool_call_end_id is not None and any(
+                        input_ids[j] == tool_call_end_id
+                        for j in range(i + 1, len(input_ids))
+                    ):
+                        continue
+                    return True
+        return False

--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -69,12 +69,12 @@ _REASONING_PARSERS_TO_REGISTER = {
         "Olmo3ReasoningParser",
     ),
     "qwen3": (
-        "qwen3_reasoning_parser",
-        "Qwen3ReasoningParser",
+        "qwen3_engine_reasoning_parser",
+        "Qwen3ParserReasoningAdapter",
     ),
     "qwen3_5": (
-        "qwen3_5_reasoning_parser",
-        "Qwen3_5ReasoningParser",
+        "qwen3_engine_reasoning_parser",
+        "Qwen3ParserReasoningAdapter",
     ),
     "seed_oss": (
         "seedoss_reasoning_parser",

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -37,6 +37,8 @@ class ReasoningParser:
     It is used to extract reasoning content from the model output.
     """
 
+    engine_based_streaming: bool = False
+
     def __init__(self, tokenizer: TokenizerLike, *args, **kwargs):
         self.model_tokenizer = tokenizer
 
@@ -46,8 +48,19 @@ class ReasoningParser:
         # whereas all tokenizers have .get_vocab()
         return self.model_tokenizer.get_vocab()
 
+    @property
+    def reasoning_start_str(self) -> str | None:
+        return None
+
+    @property
+    def reasoning_end_str(self) -> str | None:
+        return None
+
+    def has_engine_confirmed_reasoning_end(self) -> bool:
+        return False
+
     @abstractmethod
-    def is_reasoning_end(self, input_ids: list[int]) -> bool:
+    def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         """
         Check if the reasoning content ends in the input_ids.
 
@@ -62,6 +75,13 @@ class ReasoningParser:
         bool
             True if the reasoning content ends in the input_ids.
         """
+
+    def is_reasoning_end_streaming(
+        self,
+        input_ids: Sequence[int],
+        delta_ids: Sequence[int],
+    ) -> bool:
+        return self.is_reasoning_end(input_ids)
 
     @abstractmethod
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
@@ -127,6 +147,31 @@ class ReasoningParser:
         Otherwise, None is returned
         """
         return None
+
+    def adjust_request(
+        self,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        return request
+
+    def adjust_initial_state_from_prompt(
+        self,
+        prompt_token_ids: Sequence[int],
+    ) -> None:
+        return
+
+    def finish_streaming(self) -> DeltaMessage | None:
+        return None
+
+    def get_streaming_fallback_content(
+        self,
+        text: str,
+        request: ChatCompletionRequest | ResponsesRequest,
+    ) -> str | None:
+        return None
+
+    def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+        return 0
 
 
 class ReasoningParserManager:

--- a/vllm/reasoning/qwen3_engine_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_engine_reasoning_parser.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.parser.engine.registered_adapters import Qwen3ParserReasoningAdapter
+
+__all__ = ["Qwen3ParserReasoningAdapter"]

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -34,6 +34,7 @@ from transformers.utils import CONFIG_NAME as HF_CONFIG_NAME
 
 from vllm import envs
 from vllm.logger import init_logger
+from vllm.transformers_utils.gguf_utils import qwen35_gguf_config_dict
 
 from .config_parser_base import ConfigParserBase
 from .repo_utils import (
@@ -129,13 +130,26 @@ class HFConfigParser(ConfigParserBase):
         **kwargs,
     ) -> tuple[dict, PretrainedConfig]:
         kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE
-        config_dict, _ = PretrainedConfig.get_config_dict(
-            model,
-            revision=revision,
-            code_revision=code_revision,
-            token=_get_hf_token(),
-            **kwargs,
-        )
+        try:
+            config_dict, _ = PretrainedConfig.get_config_dict(
+                model,
+                revision=revision,
+                code_revision=code_revision,
+                token=_get_hf_token(),
+                **kwargs,
+            )
+        except ValueError as e:
+            if _is_unsupported_transformers_gguf_arch_error(e):
+                gguf_file = kwargs.get("gguf_file")
+                gguf_path = (
+                    Path(model) / gguf_file
+                    if gguf_file is not None
+                    else Path(model)
+                )
+                if config_dict := qwen35_gguf_config_dict(str(gguf_path)):
+                    config = _CONFIG_REGISTRY["qwen3_5"].from_dict(config_dict)
+                    return config_dict, _maybe_remap_hf_config_attrs(config)
+            raise
         # Use custom model class if it's in our registry
         model_type = config_dict.get("model_type")
         if model_type is None:
@@ -461,6 +475,13 @@ def _maybe_remap_hf_config_attrs(config: PretrainedConfig) -> PretrainedConfig:
     return config
 
 
+def _is_unsupported_transformers_gguf_arch_error(exc: ValueError) -> bool:
+    return (
+        "GGUF model with architecture" in str(exc)
+        and "is not supported yet" in str(exc)
+    )
+
+
 def maybe_override_with_speculators(
     model: str,
     tokenizer: str | None,
@@ -496,13 +517,28 @@ def maybe_override_with_speculators(
     else:
         gguf_model_repo = None
     kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE
-    config_dict, _ = PretrainedConfig.get_config_dict(
-        config_source if config_source is not None else (model if gguf_model_repo is None else gguf_model_repo),
-        revision=revision,
-        trust_remote_code=trust_remote_code,
-        token=_get_hf_token(),
-        **kwargs,
-    )
+    try:
+        config_dict, _ = PretrainedConfig.get_config_dict(
+            config_source if config_source is not None else (model if gguf_model_repo is None else gguf_model_repo),
+            revision=revision,
+            trust_remote_code=trust_remote_code,
+            token=_get_hf_token(),
+            **kwargs,
+        )
+    except ValueError as e:
+        if (
+            gguf_model_repo is not None
+            and config_source is None
+            and _is_unsupported_transformers_gguf_arch_error(e)
+        ):
+            logger.debug(
+                "Skipping speculators auto-detection for GGUF model %s because "
+                "Transformers cannot parse its GGUF architecture: %s",
+                model,
+                e,
+            )
+            return model, tokenizer, vllm_speculative_config
+        raise
     speculators_config = config_dict.get("speculators_config")
 
     if speculators_config is None:

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -2,11 +2,22 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """GGUF utility functions."""
 
+import hashlib
 from pathlib import Path
 
 import gguf
 from gguf.constants import Keys, VisionProjectorType
-from transformers import Gemma3Config, PretrainedConfig, SiglipVisionConfig
+from transformers import (
+    Gemma3Config,
+    PreTrainedTokenizerFast,
+    PretrainedConfig,
+    SiglipVisionConfig,
+)
+from transformers.integrations.ggml import convert_gguf_tokenizer
+from transformers.modeling_gguf_pytorch_utils import (
+    GGUF_TO_TRANSFORMERS_MAPPING,
+    _gguf_parse_value,
+)
 
 from vllm.logger import init_logger
 
@@ -126,6 +137,201 @@ def extract_vision_config_from_gguf(mmproj_path: str) -> "SiglipVisionConfig | N
         logger.info("Extracted vision config from mmproj.gguf metadata")
 
     return config
+
+
+def _read_gguf_scalar(
+    reader: gguf.GGUFReader,
+    key: str,
+    default: object | None = None,
+) -> object | None:
+    field = reader.get_field(key)
+    if field is None:
+        return default
+
+    value = field.contents()
+    if isinstance(value, list):
+        if len(value) == 1:
+            return value[0]
+        return value
+    return value
+
+
+def qwen35_gguf_config_dict(model: str) -> dict | None:
+    """Build a Qwen3.5 config dict from qwen35 GGUF metadata."""
+    try:
+        reader = gguf.GGUFReader(str(model))
+    except Exception:
+        return None
+
+    if _read_gguf_scalar(reader, "general.architecture") != "qwen35":
+        return None
+
+    tokens = _read_gguf_scalar(reader, "tokenizer.ggml.tokens", [])
+    linear_key_head_dim = int(
+        _read_gguf_scalar(reader, "qwen35.ssm.state_size", 128)
+    )
+    linear_value_head_dim = int(
+        _read_gguf_scalar(reader, "qwen35.ssm.state_size", 128)
+    )
+    linear_num_key_heads = int(
+        _read_gguf_scalar(reader, "qwen35.ssm.group_count")
+    )
+    qkv_tensor = next(
+        (tensor for tensor in reader.tensors if tensor.name == "blk.0.attn_qkv.weight"),
+        None,
+    )
+    if qkv_tensor is None:
+        return None
+    qkv_dim = int(qkv_tensor.shape[1])
+    linear_num_value_heads = int(
+        (qkv_dim - 2 * linear_num_key_heads * linear_key_head_dim)
+        // linear_value_head_dim
+    )
+    num_hidden_layers = int(_read_gguf_scalar(reader, "qwen35.block_count"))
+    tensor_names = {tensor.name for tensor in reader.tensors}
+    layer_types = [
+        (
+            "linear_attention"
+            if f"blk.{idx}.attn_qkv.weight" in tensor_names
+            else "full_attention"
+        )
+        for idx in range(num_hidden_layers)
+    ]
+
+    text_config = {
+        "model_type": "qwen3_5_text",
+        "vocab_size": len(tokens),
+        "hidden_size": int(_read_gguf_scalar(reader, "qwen35.embedding_length")),
+        "intermediate_size": int(
+            _read_gguf_scalar(reader, "qwen35.feed_forward_length")
+        ),
+        "num_hidden_layers": num_hidden_layers,
+        "num_attention_heads": int(
+            _read_gguf_scalar(reader, "qwen35.attention.head_count")
+        ),
+        "num_key_value_heads": int(
+            _read_gguf_scalar(reader, "qwen35.attention.head_count_kv")
+        ),
+        "max_position_embeddings": int(
+            _read_gguf_scalar(reader, "qwen35.context_length")
+        ),
+        "rms_norm_eps": float(
+            _read_gguf_scalar(reader, "qwen35.attention.layer_norm_rms_epsilon")
+        ),
+        "head_dim": int(_read_gguf_scalar(reader, "qwen35.attention.key_length")),
+        "linear_key_head_dim": linear_key_head_dim,
+        "linear_value_head_dim": linear_value_head_dim,
+        "linear_conv_kernel_dim": int(
+            _read_gguf_scalar(reader, "qwen35.ssm.conv_kernel", 4)
+        ),
+        "linear_num_key_heads": linear_num_key_heads,
+        "linear_num_value_heads": linear_num_value_heads,
+        "full_attention_interval": int(
+            _read_gguf_scalar(reader, "qwen35.full_attention_interval", 4)
+        ),
+        "layer_types": layer_types,
+        "rope_parameters": {
+            "rope_type": "default",
+            "rope_theta": float(_read_gguf_scalar(reader, "qwen35.rope.freq_base")),
+            "mrope_section": _read_gguf_scalar(
+                reader, "qwen35.rope.dimension_sections", None
+            ),
+            "mrope_interleaved": True,
+        },
+        "bos_token_id": _read_gguf_scalar(reader, "tokenizer.ggml.bos_token_id"),
+        "eos_token_id": _read_gguf_scalar(reader, "tokenizer.ggml.eos_token_id"),
+        "pad_token_id": _read_gguf_scalar(reader, "tokenizer.ggml.padding_token_id"),
+        "tie_word_embeddings": not any(
+            tensor.name == "output.weight" for tensor in reader.tensors
+        ),
+    }
+
+    config_dict = {
+        "architectures": ["Qwen3_5ForCausalLM"],
+        "model_type": "qwen3_5",
+        "text_config": text_config,
+    }
+    logger.info("Built Qwen3.5 config from qwen35 GGUF metadata: %s", model)
+    return config_dict
+
+
+def _qwen35_gguf_tokenizer_config(
+    reader: gguf.GGUFReader,
+) -> tuple[dict, dict] | None:
+    if _read_gguf_scalar(reader, "general.architecture") != "qwen35":
+        return None
+
+    parsed = {k: {} for k in GGUF_TO_TRANSFORMERS_MAPPING}
+    for gguf_key, field in reader.fields.items():
+        split = gguf_key.split(".")
+        prefix = split[0]
+        config_key = ".".join(split[1:])
+        value = [
+            _gguf_parse_value(field.parts[data_index], field.types)
+            for data_index in field.data
+        ]
+        if len(value) == 1:
+            value = value[0]
+
+        for parameter, parameter_renames in GGUF_TO_TRANSFORMERS_MAPPING.items():
+            if prefix in parameter_renames and config_key in parameter_renames[prefix]:
+                renamed_config_key = parameter_renames[prefix][config_key]
+                if renamed_config_key not in (-1, None):
+                    parsed[parameter][renamed_config_key] = value
+
+    tokenizer_dict = parsed["tokenizer"]
+    tokenizer_config = parsed["tokenizer_config"]
+    tokens = tokenizer_dict.get("tokens")
+    if not tokens:
+        return None
+
+    for id_key, token_key in (
+        ("bos_token_id", "bos_token"),
+        ("eos_token_id", "eos_token"),
+        ("pad_token_id", "pad_token"),
+        ("unk_token_id", "unk_token"),
+    ):
+        token_id = tokenizer_config.get(id_key)
+        if token_id is not None and token_key not in tokenizer_config:
+            tokenizer_config[token_key] = tokens[token_id]
+
+    return tokenizer_dict, tokenizer_config
+
+
+def qwen35_gguf_tokenizer_path(model: str) -> str | None:
+    """Materialize a HF tokenizer directory from qwen35 GGUF metadata."""
+    try:
+        model_path = Path(model)
+        reader = gguf.GGUFReader(str(model_path))
+    except Exception:
+        return None
+
+    tokenizer_parts = _qwen35_gguf_tokenizer_config(reader)
+    if tokenizer_parts is None:
+        return None
+
+    stat = model_path.stat()
+    digest = hashlib.sha256(
+        f"{model_path.resolve()}:{stat.st_size}:{stat.st_mtime_ns}".encode()
+    ).hexdigest()[:16]
+    tokenizer_dir = Path.home() / ".cache" / "vllm" / "qwen35_gguf_tokenizers" / digest
+    if (tokenizer_dir / "tokenizer.json").is_file():
+        return str(tokenizer_dir)
+
+    tokenizer_dir.mkdir(parents=True, exist_ok=True)
+    tokenizer_dict, tokenizer_config = tokenizer_parts
+    tokenizer_object, additional_kwargs = convert_gguf_tokenizer(
+        "qwen3",
+        tokenizer_dict,
+    )
+    fast_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer_object,
+        **additional_kwargs,
+        **tokenizer_config,
+    )
+    fast_tokenizer.save_pretrained(tokenizer_dir)
+    logger.info("Built Qwen3.5 tokenizer from qwen35 GGUF metadata: %s", model)
+    return str(tokenizer_dir)
 
 
 def maybe_patch_hf_config_from_gguf(


### PR DESCRIPTION
## 概述

本 PR 以正确方式同步开发仓库改动：head 分支已强制更新为从公开仓库 `gfx906/main` 派生，只包含一个内容同步提交，不引入开发仓库不同的 git 历史。

同步来源为开发仓库 `gfx906-vllm-dev` 当前 `gfx906/main` 的已提交代码快照，目标是将 Qwen3.5/Qwen3.6 GGUF 在 gfx906 ROCm 环境下的加载、推理、reasoning 兼容和 decode 性能优化合入公开仓库。

## 主要优化点

### Qwen3.5 / Qwen3.6 GGUF 支持

- 增强 qwen35 GGUF metadata 解析，支持从 GGUF 构造 Qwen3.5 配置和 tokenizer。
- 对齐 Qwen3.5 hybrid / GatedDeltaNet / linear attention 的 GGUF 权重加载路径。
- 修复 GDN projection、head layout、norm loading、state/cache 更新等兼容问题。
- 移除 linear attention dense fp16 fallback，尽量保留 GGUF quantized weights，降低额外显存占用。

### gfx906 decode 性能优化

- 新增 gfx906 专用 causal-conv / GDN recurrent decode kernel 与 fallback 路径。
- 添加 packed Qwen3.5 GDN decode 路径，减少 eager/Torch op 拆分。
- 优化 GGUF MMVQ decode，包括 shard view/cache、same-type shard fusion、IQ4_XS 与 ROCm wave size 调整。
- 新增 gfx906 RMSNorm / gated RMSNorm / Gemma RMSNorm kernel，降低 decode 阶段小 kernel 开销。

### 稳定性与输出质量保护

- Qwen3.5 GGUF on gfx906 默认降级到 `PIECEWISE` CUDA graph，避免 FULL decode graph 下 GDN state update 导致长 thinking 输出退化。
- 增加 ROCm/gfx906 平台检测、KV cache budget、Triton fallback、unified attention eager fallback 等兼容处理。
- 修复 reasoning parser 行为，接入 parser engine，改善 Qwen3/Qwen3.5 thinking 内容和正文内容分离。
- 支持 `default_chat_template_kwargs`，可显式传入 `enable_thinking` 等 chat template 参数。

### 依赖、文档与示例

- 固定 PyTorch ROCm wheel 依赖，避免默认安装 CUDA 版 torch。
- 更新 README / 示例命令，移除不再推荐的 `--enforce-eager` 示例，补充 Qwen3.5 parser 使用方式。
- 同步必要的主线 runtime input / worker 集成、parser engine 和相关测试文件。

## 验证情况

开发仓库中已进行过以下验证方向：

- Qwen3.5-4B GGUF 在 gfx906 上真实启动与 thinking 输出 smoke test。
- Qwen3.5/Qwen3.6 GGUF 小上下文启动验证。
- GGUF MMVQ、GDN packed decode、causal-conv/GDN fallback、RMSNorm kernel 等相关单测。
- reasoning/content 分离、流式输出、复杂 thinking prompt 的回归检查。
- 对 FULL decode graph 退化风险保留保护逻辑，当前默认仍使用 PIECEWISE 路径。

## 注意事项

- 本 PR 是公开仓库主线上的单提交内容同步，不包含开发仓库提交历史。
- 本 PR 不默认启用 FULL decode graph；FULL decode graph 仍需等 GDN state update 路径完成更多长 thinking、多请求、变长 batch 验证后再开放。
- 普通 FlashAttention backend 在 gfx906 上仍有额外阻塞点，当前不作为默认启用项。
- 未提交 `.omo/` 或临时调研文件。
